### PR TITLE
Polish layout structure and clean navigation styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,28 +1,43 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-CA">
   <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <meta name="theme-color" content="#dceeff"/>
-    <meta name="description" content="Yigon Kim — Mechanical Engineering Student (Aerospace Minor). Designing systems and innovations that benefit individuals and communities worldwide."/>
-    <meta name="author" content="Yigon Kim"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#dceeff" />
+    <meta
+      name="description"
+      content="Yigon Kim — Mechanical Engineering Student (Aerospace Minor). Designing systems and innovations that benefit individuals and communities worldwide."
+    />
+    <meta name="author" content="Yigon Kim" />
 
     <!-- Favicon & PWA -->
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico"/>
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png"/>
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json"/>
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <!-- Open Graph (social sharing) -->
-    <meta property="og:type" content="website"/>
-    <meta property="og:title" content="Yigon Kim | Mechanical Engineering Student | Aerospace Minor"/>
-    <meta property="og:description" content="Designing systems and innovations that benefit individuals and communities worldwide."/>
-    <meta property="og:image" content="%PUBLIC_URL%/og-image.jpg"/>
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Yigon Kim | Mechanical Engineering Student | Aerospace Minor"
+    />
+    <meta
+      property="og:description"
+      content="Designing systems and innovations that benefit individuals and communities worldwide."
+    />
+    <meta property="og:image" content="%PUBLIC_URL%/og-image.jpg" />
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image"/>
-    <meta name="twitter:title" content="Yigon Kim | Mechanical Engineering Student | Aerospace Minor"/>
-    <meta name="twitter:description" content="Designing systems and innovations that benefit individuals and communities worldwide."/>
-    <meta name="twitter:image" content="%PUBLIC_URL%/og-image.jpg"/>
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Yigon Kim | Mechanical Engineering Student | Aerospace Minor"
+    />
+    <meta
+      name="twitter:description"
+      content="Designing systems and innovations that benefit individuals and communities worldwide."
+    />
+    <meta name="twitter:image" content="%PUBLIC_URL%/og-image.jpg" />
 
     <title>Yigon Kim - Portfolio</title>
   </head>

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,24 @@
 import React from "react";
-import {Routes,Route} from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
 import ScrollToHash from "./components/ScrollToHash";
 import Home from "./views/Home";
 import Photo from "./views/Photo";
 
-const App=()=> {
+const App = () => {
   return (
     <>
-      <NavBar/>
-      <main id="main" style={{maxWidth:"1100px",margin:"0 auto",padding:"0 20px"}}>
-        <ScrollToHash/>
+      <NavBar />
+      <main id="main" className="page-shell">
+        <ScrollToHash />
         <Routes>
-          <Route path="/" element={<Home/>}/>
-          <Route path="/photo" element={<Photo/>}/>
-          <Route path="*" element={<Home/>}/>
+          <Route path="/" element={<Home />} />
+          <Route path="/photo" element={<Photo />} />
+          <Route path="*" element={<Home />} />
         </Routes>
       </main>
-      <Footer/>
+      <Footer />
     </>
   );
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+test("renders learn react link", () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,20 +1,15 @@
 import React from "react";
-import {useLocation} from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
-const Footer=()=> {
-  const y=new Date().getFullYear();
-  const {pathname}=useLocation();
-  const isPhoto=pathname.startsWith("/photo");
-
-  const shell={borderTop:"1px solid #eee",background:"#fff"};
-  const shellDark={borderTop:"1px solid rgba(255,255,255,.08)",background:"#0b1220"};
-  const inner={maxWidth:"1100px",margin:"0 auto",padding:"12px 16px",textAlign:"center",color:"#64748b"};
-  const innerDark={color:"#9fb3d9"};
+const Footer = () => {
+  const year = new Date().getFullYear();
+  const { pathname } = useLocation();
+  const isPhoto = pathname.startsWith("/photo");
 
   return (
-    <footer style={isPhoto?shellDark:shell}>
-      <div style={isPhoto?{...inner,...innerDark}:inner}>
-        © {y} Yigon Kim, All Rights Reserved.
+    <footer className={`footer${isPhoto ? " footer--dark" : ""}`}>
+      <div className="footer__inner">
+        © {year} Yigon Kim, All Rights Reserved.
       </div>
     </footer>
   );

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,53 +1,77 @@
-import React,{useEffect,useRef} from "react";
+import React, { useEffect, useRef } from "react";
 import heroImg from "../assets/images/hero.jpg";
 
-const Hero=()=> {
-  const ref=useRef(null);
+const Hero = () => {
+  const ref = useRef(null);
 
   /* parallax background (photo moves, text stays) */
-  useEffect(()=> {
-    const el=ref.current; if(!el){return;}
-    let ticking=false;
-    const onScroll=()=> {
-      if(ticking){return;}
-      ticking=true;
-      requestAnimationFrame(()=> {
-        const r=el.getBoundingClientRect();
-        const vh=window.innerHeight;
-        const maxScroll=Math.max(r.height-vh,0);
-        const scrolled=Math.min(Math.max(-r.top,0),maxScroll);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+      requestAnimationFrame(() => {
+        const r = el.getBoundingClientRect();
+        const vh = window.innerHeight;
+        const maxScroll = Math.max(r.height - vh, 0);
+        const scrolled = Math.min(Math.max(-r.top, 0), maxScroll);
 
-        const css=getComputedStyle(el);
-        const f=parseFloat(css.getPropertyValue("--pFactor"))||0.25;
-        el.style.setProperty("--pY",`${scrolled*f}px`);
-        ticking=false;
+        const css = getComputedStyle(el);
+        const f = parseFloat(css.getPropertyValue("--pFactor")) || 0.25;
+        el.style.setProperty("--pY", `${scrolled * f}px`);
+        ticking = false;
       });
     };
     onScroll();
-    window.addEventListener("scroll",onScroll,{passive:true});
-    window.addEventListener("resize",onScroll);
-    return ()=>{window.removeEventListener("scroll",onScroll);window.removeEventListener("resize",onScroll);};
-  },[]);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
 
   return (
     <section
       ref={ref}
       id="home"
       className="hero hero--parallax hero--left"
-      style={{'--heroTop':'24px','--heroH':'100vh','--pFactor':'.22','--bgBias':'48%'}}
+      style={{
+        "--heroTop": "24px",
+        "--heroH": "100vh",
+        "--pFactor": ".22",
+        "--bgBias": "48%",
+      }}
     >
-      <div className="hero__bg" style={{backgroundImage:`url(${heroImg})`}}/>
-      <div className="hero__overlay"/>
-      <div className="hero__sides"/>
+      <div
+        className="hero__bg"
+        style={{ backgroundImage: `url(${heroImg})` }}
+      />
+      <div className="hero__overlay" />
+      <div className="hero__sides" />
 
       <div className="hero__content">
-        <h1 className="hero__title hero__h1 text-gradient"
-            style={{'--gradY':'35%','--gradScale':'140%','--titleGap':'8px','--heroTitle':'80px'}}>
+        <h1
+          className="hero__title hero__h1 text-gradient"
+          style={{
+            "--gradY": "35%",
+            "--gradScale": "140%",
+            "--titleGap": "8px",
+            "--heroTitle": "80px",
+          }}
+        >
           <span className="line">Hello</span>
           <span className="line">I&apos;m Yigon</span>
         </h1>
         <p className="hero__sub clamp-2">
-          "Designing systems and innovations that benefit individuals and communities worldwide."
+          "Designing systems and innovations that benefit individuals and
+          communities worldwide."
         </p>
       </div>
     </section>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -43,9 +43,11 @@ const NavBar = () => {
           if (e.isIntersecting) setActive(e.target.id);
         });
       },
-      { rootMargin: `-${topOffset}px 0px -80% 0px`, threshold: 0 }
+      { rootMargin: `-${topOffset}px 0px -80% 0px`, threshold: 0 },
     );
-    const els = SECTIONS.map((id) => document.getElementById(id)).filter(Boolean);
+    const els = SECTIONS.map((id) => document.getElementById(id)).filter(
+      Boolean,
+    );
     els.forEach((el) => obs.observe(el));
     return () => obs.disconnect();
   }, [pathname]);
@@ -61,20 +63,44 @@ const NavBar = () => {
       <div className="nav__wrap">
         {/* Left: brand */}
         <div className="nav__brand">
-          <Link to="/" onClick={close}>Yigon Kim</Link>
+          <Link to="/" onClick={close}>
+            Yigon Kim
+          </Link>
         </div>
 
         {/* Center links (hidden on Photo via nav--compact) */}
         <nav className="nav__center">
-          <a href="/#about"     className={`nav__link${active==="about"?" nav__link--active":""}`}>About</a>
-          <a href="/#projects"  className={`nav__link${active==="projects"?" nav__link--active":""}`}>Projects</a>
-          <a href="/#experience"className={`nav__link${active==="experience"?" nav__link--active":""}`}>Experience</a>
-          <a href="/#contact"   className={`nav__link${active==="contact"?" nav__link--active":""}`}>Contact</a>
+          <a
+            href="/#about"
+            className={`nav__link${active === "about" ? " nav__link--active" : ""}`}
+          >
+            About
+          </a>
+          <a
+            href="/#projects"
+            className={`nav__link${active === "projects" ? " nav__link--active" : ""}`}
+          >
+            Projects
+          </a>
+          <a
+            href="/#experience"
+            className={`nav__link${active === "experience" ? " nav__link--active" : ""}`}
+          >
+            Experience
+          </a>
+          <a
+            href="/#contact"
+            className={`nav__link${active === "contact" ? " nav__link--active" : ""}`}
+          >
+            Contact
+          </a>
         </nav>
 
         {/* Right: Photo link (hidden on Photo via nav--compact) + hamburger */}
         <div className="nav__right">
-          <Link to="/photo" className="nav__link nav__photo">Photo</Link>
+          <Link to="/photo" className="nav__link nav__photo">
+            Photo
+          </Link>
 
           <button
             type="button"
@@ -96,11 +122,33 @@ const NavBar = () => {
         className={`nav__dropdown${menuOpen ? " nav__dropdown--open" : ""}`}
         onClick={close}
       >
-        <a href="/#about"      className={`nav__dlink${active==="about"?" nav__dlink--active":""}`}>About</a>
-        <a href="/#projects"   className={`nav__dlink${active==="projects"?" nav__dlink--active":""}`}>Projects</a>
-        <a href="/#experience" className={`nav__dlink${active==="experience"?" nav__dlink--active":""}`}>Experience</a>
-        <a href="/#contact"    className={`nav__dlink${active==="contact"?" nav__dlink--active":""}`}>Contact</a>
-        <Link to="/photo" className="nav__dlink">Photo</Link>
+        <a
+          href="/#about"
+          className={`nav__dlink${active === "about" ? " nav__dlink--active" : ""}`}
+        >
+          About
+        </a>
+        <a
+          href="/#projects"
+          className={`nav__dlink${active === "projects" ? " nav__dlink--active" : ""}`}
+        >
+          Projects
+        </a>
+        <a
+          href="/#experience"
+          className={`nav__dlink${active === "experience" ? " nav__dlink--active" : ""}`}
+        >
+          Experience
+        </a>
+        <a
+          href="/#contact"
+          className={`nav__dlink${active === "contact" ? " nav__dlink--active" : ""}`}
+        >
+          Contact
+        </a>
+        <Link to="/photo" className="nav__dlink">
+          Photo
+        </Link>
       </div>
     </header>
   );

--- a/src/components/ProjectModal.js
+++ b/src/components/ProjectModal.js
@@ -1,51 +1,95 @@
-import React,{useEffect} from "react";
-import {createPortal} from "react-dom";
+import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
 
-const ProjectModal=({item,onClose})=> {
+const ProjectModal = ({ item, onClose }) => {
   // keep hooks unconditional; guard logic inside
-  useEffect(()=> {
-    if(!item){return;}
-    const prev=document.body.style.overflow;
-    document.body.style.overflow="hidden";
-    const onKey=(e)=>{if(e.key==="Escape"){onClose();}};
-    window.addEventListener("keydown",onKey);
-    return ()=>{document.body.style.overflow=prev;window.removeEventListener("keydown",onKey);};
-  },[item,onClose]);
+  useEffect(() => {
+    if (!item) {
+      return;
+    }
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = prev;
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [item, onClose]);
 
-  if(!item){return null;}
+  if (!item) {
+    return null;
+  }
 
-  const meta=[item.date,item.location,item.affiliate].filter(Boolean);
-  
+  const meta = [item.date, item.location, item.affiliate].filter(Boolean);
+
   return createPortal(
-    <div className="modal" role="dialog" aria-modal="true" aria-label={`${item.title} details`} onClick={()=>{onClose();}}>
-      <div className="modal__panel" onClick={(e)=>{e.stopPropagation();}}>
-        <button className="modal__close" type="button" aria-label="Close" onClick={()=>{onClose();}}>×</button>
+    <div
+      className="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${item.title} details`}
+      onClick={() => {
+        onClose();
+      }}
+    >
+      <div
+        className="modal__panel"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <button
+          className="modal__close"
+          type="button"
+          aria-label="Close"
+          onClick={() => {
+            onClose();
+          }}
+        >
+          ×
+        </button>
 
         {/* scrollable content */}
         <div className="modal__scroll">
-          <div className="modal__media" style={{backgroundImage:`url(${item.cover})`}}/>
+          <div
+            className="modal__media"
+            style={{ backgroundImage: `url(${item.cover})` }}
+          />
           <div className="modal__body">
-            <h3 className="modal__title" >{item.title}</h3>
-            
-             {meta.length>0&&(
-            <div className="modal__meta">{meta.join(" • ")}</div>
+            <h3 className="modal__title">{item.title}</h3>
+
+            {meta.length > 0 && (
+              <div className="modal__meta">{meta.join(" • ")}</div>
             )}
-            
-            {item.keywords&&item.keywords.length>0&&(
+
+            {item.keywords && item.keywords.length > 0 && (
               <div className="modal__tags">
-                {item.keywords.map((k,i)=>{return(<span key={i} className="tag">{k}</span>);})}
+                {item.keywords.map((k, i) => {
+                  return (
+                    <span key={i} className="tag">
+                      {k}
+                    </span>
+                  );
+                })}
               </div>
             )}
-            
-            <p className="modal__desc">{item.description||"More details coming soon."}</p>
+
+            <p className="modal__desc">
+              {item.description || "More details coming soon."}
+            </p>
 
             {/* additional images */}
-            {item.images&&item.images.length>0&&(
+            {item.images && item.images.length > 0 && (
               <div className="modal__gallery">
-                {item.images.map((src,i)=> {
+                {item.images.map((src, i) => {
                   return (
                     <figure key={i} className="g">
-                      <img src={src} alt={`${item.title} image ${i+1}`}/>
+                      <img src={src} alt={`${item.title} image ${i + 1}`} />
                     </figure>
                   );
                 })}
@@ -55,7 +99,7 @@ const ProjectModal=({item,onClose})=> {
         </div>
       </div>
     </div>,
-    document.body
+    document.body,
   );
 };
 

--- a/src/components/ScrollToHash.js
+++ b/src/components/ScrollToHash.js
@@ -1,11 +1,16 @@
-import {useEffect} from "react";
-import {useLocation} from "react-router-dom";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
-const ScrollToHash=()=> {
-  const {hash}=useLocation();
-  useEffect(()=> {
-    if(hash){const el=document.querySelector(hash); if(el){el.scrollIntoView({behavior:"smooth"});}}
-  },[hash]);
+const ScrollToHash = () => {
+  const { hash } = useLocation();
+  useEffect(() => {
+    if (hash) {
+      const el = document.querySelector(hash);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, [hash]);
   return null;
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,9 @@
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
-:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
-
-img{max-width:100%;display:block;}
+img {
+  max-width: 100%;
+  display: block;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
 import React from "react";
-import {createRoot} from "react-dom/client";
-import {BrowserRouter} from "react-router-dom";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
-import "./index.css";
-import "./styles/sections.css";
 import "./styles/theme.css";
+import "./index.css";
 import "./styles/nav.css";
+import "./styles/sections.css";
+import "./styles/footer.css";
 
-
-const rootEl=document.getElementById("root");
+const rootEl = document.getElementById("root");
 createRoot(rootEl).render(
   <BrowserRouter>
-    <App/>
-  </BrowserRouter>
+    <App />
+  </BrowserRouter>,
 );

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,6 +1,6 @@
-const reportWebVitals = onPerfEntry => {
+const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);
       getFCP(onPerfEntry);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -1,10 +1,30 @@
-.footer{border-top:1px solid rgba(15,23,42,.06);background:#fff;}
-.footer p{margin:12px 0;color:var(--muted);font-size:14px;text-align:center;}
-
-/* Dark footer on /photo */
-.photo-dark .footer{
-  background:#0b1220 !important;
-  color:#aeb7cc !important;
-  border-top:1px solid rgba(255,255,255,.08) !important;
+.footer {
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
+  background: #fff;
 }
-.photo-dark .footer a{color:#c7d6ff;}
+
+.footer__inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 16px 20px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.footer__inner p {
+  margin: 0;
+}
+
+.footer a {
+  color: inherit;
+}
+
+.footer--dark {
+  background: #0b1220;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.footer--dark .footer__inner {
+  color: #aeb7cc;
+}

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -1,176 +1,227 @@
-/* Shell */
-.nav{position:sticky;top:0;z-index:50;transition:background .25s,border-color .25s,color .25s;}
-.nav--clear{
-  background:rgba(0,0,0,.28);
-  -webkit-backdrop-filter:saturate(180%) blur(6px);
-  backdrop-filter:saturate(180%) blur(6px);
-  border-bottom:1px solid rgba(255,255,255,.08);
-  color:#fff;
-}
-.nav--glass{
-  background:rgba(255,255,255,.7);
-  -webkit-backdrop-filter:saturate(180%) blur(12px);
-  backdrop-filter:saturate(180%) blur(12px);
-  border-bottom:1px solid rgba(15,23,42,.08);
-  color:var(--ink);
-}
+/* =============================================
+   Global navigation
+   ============================================= */
 
-/* Layout: brand (left) | center (absolute) | right (photo/hamburger) */
-.nav__wrap{
-  position:relative;
-  display:flex;align-items:center;justify-content:space-between;
-  max-width:var(--max);margin:0 auto;padding:6px 14px;min-height:var(--navH);
-}
-.nav__brand{flex:0 0 auto;font-weight:800;letter-spacing:.2px;}
-.nav__center{
-  position:absolute;left:50%;transform:translateX(-50%);
-  display:flex;gap:18px;align-items:center;
-}
-.nav__right{flex:0 0 auto;display:flex;gap:10px;align-items:center;}
-
-/* Links with underline like the ref */
-.nav__link{position:relative;padding:8px 10px;transition:color .2s;-webkit-tap-highlight-color:transparent;}
-.nav__link:after{content:"";position:absolute;left:10px;right:calc(100% - 10px);bottom:2px;height:2px;background:var(--accent);opacity:.95;transition:right .25s;}
-.nav__link:hover:after{right:10px;}
-.nav__link--active:after{right:10px;}
-/* remove click/focus box in nav only (keep keyboard outlines elsewhere) */
-.nav a:focus,.nav a:focus-visible,.nav__toggle:focus,.nav__toggle:focus-visible{outline:0 !important;box-shadow:none !important;}
-.nav--clear .nav__link,.nav--clear .nav__brand a{color:#fff;}
-
-/* Two-line hamburger (mobile only, pinned right) */
-.nav__toggle{
-  display:none;
-  width:34px;height:24px;
-  border:0;background:transparent;padding:0;cursor:pointer;
-  -webkit-tap-highlight-color:transparent;
-  display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;
-}
-.nav__toggle span{
-  display:block;width:22px;height:2px;border-radius:2px;
-  background:#fff; /* default = white for the dark (clear) state */
-  transition:transform .2s,opacity .2s,background-color .25s;
-}
-.nav--clear .nav__toggle span{background:#fff;}          /* top over hero */
-.nav--glass .nav__toggle span{background:var(--ink);}     /* scrolled = black (#0f172a) */
-
-/* Mobile dropdown */
-.nav__dropdown{
-  display:none;position:absolute;top:100%;left:0;right:0;background:rgba(255,255,255,.97);
-  border-bottom:1px solid rgba(15,23,42,.08);box-shadow:var(--shadow);
-}
-.nav__dropdown--open{display:block;}
-.nav__dlink{display:block;padding:12px 16px;border-top:1px solid rgba(15,23,42,.06);color:var(--ink);}
-.nav__dlink--active{color:var(--accent);}
-
-/* Responsive */
-@media (max-width:860px){
-  .nav__center{display:none;}            /* hide center links on mobile */
-  .nav__right .nav__photo{display:none;} /* hide Photo text on mobile */
-  .nav__toggle{display:flex;}            /* show 2-line hamburger on the right */
-}
-@media (min-width:861px){
-  .nav__toggle{display:none !important;} /* hide hamburger on desktop */
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 80;
+  display: block;
+  color: var(--ink);
+  transition:
+    background 0.25s ease,
+    border-color 0.25s ease,
+    color 0.25s ease;
 }
 
-/* === Force dark navbar on /photo === */
-.nav.nav--dark{
-  background:rgba(11,18,32,.85) !important;       /* dark glass */
-  color:#e6eefc;
-  box-shadow:0 1px 0 rgba(255,255,255,.06);
-  backdrop-filter:saturate(120%) blur(10px);
+.nav--clear {
+  background: rgba(0, 0, 0, 0.28);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: saturate(180%) blur(6px);
+  color: #fff;
 }
 
-/* If scroll adds nav--glass or nav--clear, stay dark */
-.nav.nav--dark.nav--glass,
-.nav.nav--dark.nav--clear{
-  background:rgba(11,18,32,.85) !important;
-  box-shadow:0 1px 0 rgba(255,255,255,.06);
+.nav--glass {
+  background: rgba(255, 255, 255, 0.7);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  backdrop-filter: saturate(180%) blur(12px);
 }
 
-/* Links + brand in dark navbar */
-.nav.nav--dark .nav__brand a,
-.nav.nav--dark .nav__link{ color:#e6eefc; }
+.nav__wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 6px 14px;
+  min-height: var(--navH);
+  gap: 18px;
+}
 
-/* Two-line hamburger visible & white in dark navbar */
-.nav.nav--dark .nav__toggle{ display:flex; }
-.nav.nav--dark .nav__toggle span{ background:#fff; }
+.nav__brand {
+  flex: 0 0 auto;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+}
 
-/* Keep dropdown white (as requested) even on dark page */
-.nav__dropdown{ background:#ffffff; color:#0f172a; }
+.nav__brand a {
+  color: inherit;
+}
 
-/* On photo: hide center links & the 'Photo' link; always show toggle */
-.nav.nav--compact .nav__center,
-.nav.nav--compact .nav__photo{ display:none !important; }
-.nav.nav--showToggle .nav__toggle{ display:flex !important; }
+.nav__center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
 
-/* === FORCE WHITE DROPDOWN (everywhere, incl. /photo) === */
-.nav__dropdown{
-  position: fixed;                  /* detach from header; span full width */
+.nav__right {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 10px;
+  color: inherit;
+  font-weight: 500;
+  transition: color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nav__link::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: calc(100% - 10px);
+  bottom: 2px;
+  height: 2px;
+  background: var(--accent);
+  opacity: 0.95;
+  transition: right 0.25s ease;
+}
+
+.nav__link:hover::after,
+.nav__link--active::after {
+  right: 10px;
+}
+
+.nav__link--active {
+  color: var(--accent);
+}
+
+.nav a:focus,
+.nav a:focus-visible,
+.nav__toggle:focus,
+.nav__toggle:focus-visible {
+  outline: 0 !important;
+  box-shadow: none !important;
+}
+
+.nav__toggle {
+  display: none;
+  width: 34px;
+  height: 24px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  -webkit-tap-highlight-color: transparent;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.nav__toggle span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease,
+    background-color 0.25s ease;
+}
+
+.nav__dropdown {
+  position: fixed;
   top: var(--navH);
   left: 0;
   right: 0;
-  background:#ffffff !important;    /* white panel as requested */
-  color:#0f172a !important;         /* dark text inside */
-  border-bottom:1px solid rgba(15,23,42,.08);
-  box-shadow:0 12px 24px rgba(15,23,42,.18);
+  background: #fff;
+  color: #0f172a;
   transform: translateY(-10px);
-  opacity:0;
-  pointer-events:none;
-  transition: transform .18s ease, opacity .18s ease;
-  z-index: 70;                      /* above the page & just under the nav */
+  opacity: 0;
+  pointer-events: none;
+  border-bottom: 0;
+  box-shadow: none;
+  transition:
+    transform 0.18s ease,
+    opacity 0.18s ease;
+  z-index: 70;
 }
 
-.nav__dropdown--open{
+.nav__dropdown--open {
   transform: translateY(0);
-  opacity:1;
-  pointer-events:auto;
+  opacity: 1;
+  pointer-events: auto;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
 }
 
-/* Dropdown items */
-.nav__dlink{
-  display:block;
-  padding:14px 20px;
-  color:#0f172a !important;
-}
-.nav__dlink:hover{ background:rgba(15,23,42,.04); }
-
-/* Keep it white even with dark navbar */
-.nav.nav--dark .nav__dropdown{ background:#fff !important; color:#0f172a !important; }
-
-/* If you don't already have this */
-.nav{ position:fixed; top:0; left:0; right:0; z-index: 80; }
-
-/* Ensure header is above everything */
-.nav{ position:fixed; top:0; left:0; right:0; z-index:80; }
-
-/* Force white dropdown on open, completely invisible when closed */
-.nav__dropdown{
-  position:fixed;
-  top:var(--navH);
-  left:0; right:0;
-  background:#fff;
-  color:#0f172a;
-  transform:translateY(-10px);
-  opacity:0;
-  pointer-events:none;
-  /* when CLOSED, no border so you don't see a line */
-  border-bottom:0;
-  box-shadow:none;
-  transition:transform .18s ease, opacity .18s ease;
-  z-index:70;
-}
-.nav__dropdown--open{
-  transform:translateY(0);
-  opacity:1;
-  pointer-events:auto;
-  border-bottom:1px solid rgba(15,23,42,.08);
-  box-shadow:0 12px 24px rgba(15,23,42,.18);
+.nav__dlink {
+  display: block;
+  padding: 14px 20px;
+  color: inherit;
 }
 
-/* Dropdown links */
-.nav__dlink{display:block;padding:14px 20px;color:#0f172a;}
-.nav__dlink:hover{background:rgba(15,23,42,.04);}
+.nav__dlink:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
 
-/* Keep toggle visible & white on dark nav (photo page) */
-.nav--dark .nav__toggle span{ background:#fff; }
-.nav--showToggle .nav__toggle{ display:flex; }   /* show hamburger on desktop for /photo */
+.nav__dlink--active {
+  color: var(--accent);
+}
+
+@media (max-width: 860px) {
+  .nav__center {
+    display: none;
+  }
+
+  .nav__right .nav__photo {
+    display: none;
+  }
+
+  .nav__toggle {
+    display: flex;
+  }
+}
+
+@media (min-width: 861px) {
+  .nav__toggle {
+    display: none !important;
+  }
+}
+
+.nav--compact .nav__center,
+.nav--compact .nav__photo {
+  display: none !important;
+}
+
+.nav--showToggle .nav__toggle {
+  display: flex !important;
+}
+
+.nav--dark {
+  background: rgba(11, 18, 32, 0.85) !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06) !important;
+  color: #e6eefc !important;
+  backdrop-filter: saturate(120%) blur(10px);
+}
+
+.nav--dark .nav__brand a,
+.nav--dark .nav__link {
+  color: #e6eefc;
+}
+
+.nav--dark .nav__toggle span {
+  background: #fff;
+}
+
+.nav__dropdown {
+  background: #fff !important;
+  color: #0f172a !important;
+}

--- a/src/styles/sections.css
+++ b/src/styles/sections.css
@@ -1,480 +1,818 @@
-/* Smooth anchor scroll */
-html{scroll-behavior:smooth;}
+/* =============================================
+   Section + hero presentation styles
+   ============================================= */
 
-:root{
-  /* knobs you can tune anytime */
-  --sectionTitle:40px;           /* desktop title size */
-  --sectionTitleMobile:36px;     /* mobile title size */
-  --sectionTitleWeight:800;      /* boldness */
-  --sectionTitleLH:1.12;         /* line-height */
+:root {
+  /* Section heading controls */
+  --sectionTitle: 40px;
+  --sectionTitleMobile: 32px;
+  --sectionTitleWeight: 800;
+  --sectionTitleLH: 1.12;
+  --titleBelow: 16px;
 
-  --sectionGap:80px;             /* vertical spacing between sections */
-  --sectionGapMobile:72px;       /* mobile spacing */
-  --titleBelow:16px;             /* space under the title */
+  /* Vertical rhythm */
+  --sectionGap: 80px;
+  --sectionGapMobile: 64px;
 }
 
-/* make your existing heading rule use the under-title gap knob */
-.section h2{margin:0 0 var(--titleBelow) 0;}
-
-/* Bridge old class names to the new knobs */
-.about__title,
-.projects__title,
-.experience__title,
-.contact__title{
-  font-size:var(--sectionTitle) !important;
-  line-height:var(--sectionTitleLH) !important;
-  font-weight:var(--sectionTitleWeight) !important;
-  margin:0 0 var(--titleBelow) 0 !important;
+/* ---------------------------------------------
+   Shared section scaffolding
+   --------------------------------------------- */
+.section {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: var(--sectionGap) 0;
 }
-@media(max-width:720px){
-  .about__title,
-  .projects__title,
-  .experience__title,
-  .contact__title{
-    font-size:var(--sectionTitleMobile) !important;
+
+.section
+  :is(
+    h2,
+    .section__title,
+    .about__title,
+    .projects__title,
+    .experience__title,
+    .contact__title
+  ) {
+  margin: 0 0 var(--titleBelow);
+  font-size: var(--sectionTitle);
+  line-height: var(--sectionTitleLH);
+  font-weight: var(--sectionTitleWeight);
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--sectionGapMobile) 0;
+  }
+
+  .section
+    :is(
+      h2,
+      .section__title,
+      .about__title,
+      .projects__title,
+      .experience__title,
+      .contact__title
+    ) {
+    font-size: var(--sectionTitleMobile);
   }
 }
 
-/* Hero (full-bleed, under nav) */
-.hero{
-  position:relative;overflow:hidden;
-  min-height:120vh;                              /* gives room for bg to move */
-  margin-top:calc(-1*var(--navH));margin-bottom:24px;
-  width:100vw;margin-left:calc(50% - 50vw);margin-right:calc(50% - 50vw);
-  padding-top:var(--navH);
-  display:flex;align-items:center;
+/* =============================================
+   Hero (full-bleed, parallax background)
+   ============================================= */
+.hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  min-height: 120vh;
+  padding-top: var(--navH);
+  margin: calc(-1 * var(--navH)) calc(50% - 50vw) 24px;
+  width: 100vw;
 }
 
-/* Actual image layer we move */
-.hero__bg{
-  position:absolute;inset:0;
-  background-size:cover;background-position:center;
-  transform:translate3d(0,var(--pY,0px),0);      /* parallax offset */
-  will-change:transform;
-  /* a touch of overscale prevents edges showing when translated */
-  scale:1.06;
-  z-index:0;
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transform: translate3d(0, var(--pY, 0px), 0);
+  will-change: transform;
+  scale: 1.06;
+  z-index: 0;
 }
 
-.hero__overlay{
-  position:absolute;inset:0;
-  background:linear-gradient(180deg,rgba(0,0,0,.55) 0%,rgba(0,0,0,.30) 30%,rgba(0,0,0,.15) 60%,rgba(0,0,0,0) 100%);
-  z-index:1;
+.hero__overlay,
+.hero__sides {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
 }
-.hero__sides{position:absolute;inset:0;pointer-events:none;
+
+.hero__overlay {
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.55) 0%,
+    rgba(0, 0, 0, 0.3) 30%,
+    rgba(0, 0, 0, 0.15) 60%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.hero__sides {
   background:
-    linear-gradient(90deg,rgba(0,0,0,.45) 0,rgba(0,0,0,0) 120px),
-    linear-gradient(270deg,rgba(0,0,0,.45) 0,rgba(0,0,0,0) 120px);
-    z-index:1;
+    linear-gradient(90deg, rgba(0, 0, 0, 0.45) 0, rgba(0, 0, 0, 0) 120px),
+    linear-gradient(270deg, rgba(0, 0, 0, 0.45) 0, rgba(0, 0, 0, 0) 120px);
 }
 
-/* Text stays pinned; confined to site width */
-.hero__content{
-  position:sticky;top:calc(var(--navH) + var(--heroTop,16px));
-  width:auto;max-width:var(--max);margin:0 auto;
-  display:flex;flex-direction:column;color:#fff;padding:60px 20px;
-  z-index:2;
+.hero__content {
+  position: sticky;
+  top: calc(var(--navH) + var(--heroTop, 16px));
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 60px 20px;
+  width: auto;
+  max-width: var(--max);
+  margin: 0 auto;
+  color: #fff;
 }
 
-/* Choose ONE alignment on the <section> class list */
-.hero--left .hero__content{align-items:flex-start;text-align:left;}
-
-/* Type */
-.hero__h1{font-size:var(--heroTitle,80px);line-height:1.08;margin:0 0 8px 0;}
-.hero__tag{font-weight:400;margin:0 0 8px 0;}
-.hero__sub{max-width:400;margin:0 0 16px 0;opacity:.95;}
-.hero__actions{display:flex;gap:10px;flex-wrap:wrap;}
-@media (max-width:720px){.hero__h1{font-size:48px;}}
-
-/* Sections */
-.section{
-  max-width:var(--max);
-  margin:0 auto;
-  padding:var(--sectionGap) 0;              /* controls space between sections */
-}
-.section h2{
-  margin:0 0 12px 0;
-  font-size:var(--sectionTitle);            /* controls title size */
-  line-height:var(--sectionTitleLH);
-  font-weight:var(--sectionTitleWeight);
-}
-@media(max-width:720px){
-  .section{padding:var(--sectionGapMobile) 0;}
-  .section h2{font-size:var(--sectionTitleMobile);}
+.hero--left .hero__content {
+  text-align: left;
+  align-items: flex-start;
 }
 
-
-/* Projects grid */
-.projects-grid{display:grid;gap:16px;}
-@media(min-width:720px){.projects-grid{grid-template-columns:repeat(3,1fr);}}
-
-/* Cards */
-.card{background:#fff;border:1px solid rgba(15,23,42,.06);border-radius:16px;box-shadow:0 10px 24px rgba(15,23,42,.08);}
-.proj-card{position:relative;overflow:hidden;}
-.proj-card__body{padding:14px;}
-.proj-card__hover{position:absolute;inset:0;background:rgba(15,23,42,.6);color:#fff;opacity:0;transition:opacity .2s;display:flex;align-items:center;justify-content:center;text-align:center;padding:12px;}
-.proj-card:hover .proj-card__hover{opacity:1;}
-
-/* Timeline */
-.timeline{position:relative;margin-top:8px;padding-left:22px;}
-.timeline:before{content:"";position:absolute;left:9px;top:0;bottom:0;width:2px;background:rgba(15,23,42,.12);}
-.timeline-item{position:relative;margin:0 0 18px 0;}
-.timeline-item:before{content:"";position:absolute;left:-1px;top:6px;width:12px;height:12px;border-radius:999px;background:var(--accent);}
-.timeline-item__card{padding:12px 14px;border-radius:16px;background:#fff;border:1px solid rgba(15,23,42,.06);box-shadow:0 10px 24px rgba(15,23,42,.08);}
-.timeline-item__title{margin:0 0 4px 0;font-weight:700;}
-.timeline-item__meta{margin:0 0 8px 0;color:var(--muted);font-size:14px;}
-
-/* Contact form */
-.form{display:grid;gap:12px;max-width:680px;}
-.input,.textarea{width:100%;padding:12px 14px;border-radius:12px;border:1px solid rgba(15,23,42,.12);}
-.textarea{min-height:140px;resize:vertical;}
-
-/* === HERO TITLE GRADIENT === */
-.text-gradient{
-  /* adjustable gradient colors + placement */
-  --gradFrom:#8caff9;       /* light blue */
-  --gradMid:#c4dffc;        /* your accent blue */
-  --gradTo:#ffffff;         /* pale blue */
-  --gradY:50%;              /* vertical position of gradient (0–100%) */
-  --gradScale:100%;         /* vertical scale of gradient (e.g., 120%) */
-
-  background-image:linear-gradient(180deg,var(--gradFrom),var(--gradMid),var(--gradTo));
-  background-size:100% var(--gradScale);
-  background-position:50% var(--gradY);
-  color:#fff; /* fallback */
+.hero__h1 {
+  margin: 0;
+  font-size: var(--heroTitle, 80px);
+  line-height: 1.08;
 }
 
-/* Clip + stroke for crisp edges */
-@supports (-webkit-background-clip:text) or (background-clip:text){
-  .text-gradient{
-    -webkit-background-clip:text;background-clip:text;
-    -webkit-text-fill-color:transparent;color:transparent;
-    /* subtle edge to avoid punch-through look */
-    -webkit-text-stroke:.6px rgba(0,0,0,.10);
-    text-shadow:none;
+.hero__title {
+  padding: 1px 0;
+  line-height: 1.08;
+}
+
+.hero__title .line {
+  display: block;
+}
+
+.hero__title .line + .line {
+  margin-top: var(--titleGap, 8px);
+}
+
+.hero__tag {
+  margin: 0;
+  font-weight: 400;
+}
+
+.hero__sub {
+  margin: var(--titleToTag, 14px) 0 0;
+  max-width: var(--tagWidth, 60ch);
+  font-size: var(--heroSub, 18px);
+  font-weight: 400;
+  line-height: 1.4;
+  opacity: 0.95;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+@media (max-width: 720px) {
+  .hero__h1 {
+    font-size: 48px;
   }
 }
 
-/* === HERO TITLE SPACING === */
-.hero__title{padding:1px 0; line-height:1.08;}
-.hero__title .line{display:block;}
-.hero__title .line+.line{margin-top:var(--titleGap,8px);}
+/* Text gradient for hero heading */
+.text-gradient {
+  --gradFrom: #8caff9;
+  --gradMid: #c4dffc;
+  --gradTo: #ffffff;
+  --gradY: 50%;
+  --gradScale: 100%;
 
-/* Tagline now uses the thinner style that used to be hero_sub */
-.hero__sub{
-  font-weight:400;                 /* thinner */
-  font-size:var(--heroSub,18px);
-  line-height:1.4;
-  max-width:var(--tagWidth,60ch);  /* width knob so it wraps to ~2 lines */
-  margin:var(--titleToTag,14px) 0 0 0;
-  opacity:.95;
+  background-image: linear-gradient(
+    180deg,
+    var(--gradFrom),
+    var(--gradMid),
+    var(--gradTo)
+  );
+  background-size: 100% var(--gradScale);
+  background-position: 50% var(--gradY);
+  color: #fff;
 }
 
-/* Fallback (works everywhere via the legacy WebKit hack) */
-.clamp-2{
-  overflow:hidden;
-  display:-webkit-box;
-  -webkit-box-orient:vertical;
-  -webkit-line-clamp:2;
-}
-
-/* Prefer the standard property when supported */
-@supports (line-clamp: 2){
-  .clamp-2{
-    display:block;          /* no need for -webkit-box */
-    line-clamp:2;           /* standard */
+@supports (-webkit-background-clip: text) or (background-clip: text) {
+  .text-gradient {
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    -webkit-text-stroke: 0.6px rgba(0, 0, 0, 0.1);
+    text-shadow: none;
   }
 }
 
-/* ===== About (reference-like 2-column) ===== */
-.about{--aboutGap:24px;--aboutColL:1.1fr;--aboutColR:.9fr;--aboutRadius:16px;}
-
-.about__wrap{
-  display:grid;gap:var(--aboutGap);align-items:center;
-  /* clamp to a pleasant readable width; the section already centers via .section */
-  grid-template-columns:1fr;
-}
-@media(min-width:900px){
-  .about__wrap{grid-template-columns:var(--aboutColL) var(--aboutColR);}
+/* Clamp utility */
+.clamp-2 {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
-.about__title{margin:0 0 10px 0;}
-.about__p{
-  margin:0;
-  /* balance improves multi-word line breaks for large paragraphs */
-  text-wrap:balance;
-  color:var(--ink);
-}
-
-.about__media{margin:0;}
-.about__img{width:100%;height:auto;display:block;border-radius:16px;box-shadow:var(--shadow);}
-.about__img--sq{aspect-ratio:1/1;object-fit:cover;} /* perfect square crop */
-
-.about__cap{margin-top:4px;font-size:12px;color:var(--muted);letter-spacing:.2px;margin-left:10px;}
-/* On narrow screens, stack text above image to keep reading order clean */
-@media(max-width:899px){
-  .about__text{order:1;}
-  .about__media{order:2;}
-}
-
-.about__p span[aria-hidden="true"]{font-size:.95em;line-height:1;transform:translateY(1px);}
-
-/* === Projects (canonical) === */
-.projects__list{
-  display:grid;
-  gap:16px;
-  grid-template-columns:repeat(1,minmax(0,1fr));  /* mobile */
-}
-@media(min-width:720px){
-  .projects__list{grid-template-columns:repeat(2,minmax(0,1fr));}  /* tablet */
-}
-@media(min-width:1200px){
-  .projects__list{grid-template-columns:repeat(3,minmax(0,1fr));}  /* desktop */
-}
-
-.proj-card{
-  position:relative;display:block;width:100%;
-  border:0;background:transparent;cursor:pointer;
-  border-radius:16px;overflow:hidden;box-shadow:var(--shadow);
-  text-align:left;-webkit-tap-highlight-color:transparent;
-}
-
-/* Ratio: 21:9 by default; switch to 16:9 at ≥1200px (3-up) */
-.proj-card--wide{aspect-ratio:21/9;}
-@media(min-width:1200px){.proj-card--wide{aspect-ratio:16/9;}}
-
-/* Fallback ONLY when aspect-ratio isn't supported */
-@supports not (aspect-ratio:1/1){
-  .proj-card--wide::before{content:"";display:block;padding-top:42.857%;} /* 9/21 */
-  @media(min-width:1200px){
-    .proj-card--wide::before{content:"";display:block;padding-top:56.25%;} /* 9/16 */
+@supports (line-clamp: 2) {
+  .clamp-2 {
+    display: block;
+    line-clamp: 2;
   }
 }
 
-.proj-card__img{
-  position:absolute;inset:0;background-size:cover;background-position:center;
-  transform:scale(1.02);transition:transform .25s ease-out;will-change:transform;
+/* =============================================
+   About
+   ============================================= */
+.about {
+  --aboutGap: 24px;
+  --aboutColL: 1.1fr;
+  --aboutColR: 0.9fr;
+  --aboutRadius: 16px;
 }
-.proj-card:hover .proj-card__img{transform:scale(1.06);}
 
-.proj-card__label{
-  position:absolute;left:0;right:0;bottom:0;padding:14px 16px;color:#fff;
-  background:linear-gradient(180deg,transparent 0%,rgba(0,0,0,.55) 100%);
+.about__wrap {
+  display: grid;
+  gap: var(--aboutGap);
+  grid-template-columns: 1fr;
+  align-items: center;
 }
-.proj-card__title{font-weight:800;letter-spacing:.2px;}
 
-/* Hover overlay */
-.proj-card__hover{
-  position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
-  text-align:center;padding:12px;color:#fff;opacity:0;transition:opacity .18s ease-out;
-  background:rgba(0,0,0,.55);backdrop-filter:blur(1.5px);
+@media (min-width: 900px) {
+  .about__wrap {
+    grid-template-columns: var(--aboutColL) var(--aboutColR);
+  }
 }
+
+.about__title {
+  margin: 0 0 10px;
+}
+
+.about__p {
+  margin: 0;
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+.about__media {
+  margin: 0;
+}
+
+.about__img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: var(--aboutRadius);
+  box-shadow: var(--shadow);
+}
+
+.about__img--sq {
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.about__cap {
+  margin: 4px 0 0 10px;
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.2px;
+}
+
+.about__p span[aria-hidden="true"] {
+  font-size: 0.95em;
+  line-height: 1;
+  transform: translateY(1px);
+}
+
+@media (max-width: 899px) {
+  .about__text {
+    order: 1;
+  }
+
+  .about__media {
+    order: 2;
+  }
+}
+
+/* =============================================
+   Projects grid + modal
+   ============================================= */
+.projects__list {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 720px) {
+  .projects__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .projects__list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.proj-card {
+  position: relative;
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.proj-card--wide {
+  aspect-ratio: 21 / 9;
+}
+
+@media (min-width: 1200px) {
+  .proj-card--wide {
+    aspect-ratio: 16 / 9;
+  }
+}
+
+@supports not (aspect-ratio: 1 / 1) {
+  .proj-card--wide::before {
+    content: "";
+    display: block;
+    padding-top: 42.857%;
+  }
+
+  @media (min-width: 1200px) {
+    .proj-card--wide::before {
+      padding-top: 56.25%;
+    }
+  }
+}
+
+.proj-card__img {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transform: scale(1.02);
+  transition: transform 0.25s ease-out;
+  will-change: transform;
+}
+
+.proj-card:hover .proj-card__img,
+.proj-card:focus-visible .proj-card__img {
+  transform: scale(1.06);
+}
+
+.proj-card__label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 14px 16px;
+  color: #fff;
+  background: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.55) 100%);
+}
+
+.proj-card__title {
+  font-weight: 800;
+  letter-spacing: 0.2px;
+}
+
+.proj-card__hover {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  text-align: center;
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.18s ease-out;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(1.5px);
+}
+
 .proj-card:hover .proj-card__hover,
-.proj-card:focus-visible .proj-card__hover{opacity:1;}
-
-.proj-card__kw{font-size:15px;line-height:1.35;letter-spacing:.2px;opacity:.98;}
-
-/* ===== Modal (80% width, internal scroll, closable) ===== */
-.modal{position:fixed;inset:0;background:rgba(15,23,42,.55);backdrop-filter:blur(2px);display:flex;align-items:center;justify-content:center;padding:20px;z-index:60;}
-.modal__panel{
-  position:relative;display:flex;flex-direction:column;
-  width:min(1200px,80vw);max-height:85vh;background:#fff;border-radius:16px;overflow:hidden;
-  box-shadow:0 24px 60px rgba(15,23,42,.35);
-}
-.modal__close{
-  position:absolute;top:8px;right:10px;border:0;background:transparent;cursor:pointer;
-  font-size:28px;line-height:1;padding:6px 8px;color:#111;-webkit-tap-highlight-color:transparent;z-index:2;
+.proj-card:focus-visible .proj-card__hover {
+  opacity: 1;
 }
 
-/* the scrollable area (keeps close button fixed) */
-.modal__scroll{overflow:auto;display:block;}
-
-/* header media */
-.modal__media{aspect-ratio:21/9;background-size:cover;background-position:center;}
-
-/* body + text */
-.modal__body{padding:14px 16px 18px 16px;}
-.modal__title{margin:0 0 6px 0;font-size:22px;}
-.modal__tags{display:flex;flex-wrap:wrap;gap:8px;margin:6px 0 10px 0;}
-.tag{font-size:12px;padding:4px 8px;border:1px solid rgba(15,23,42,.12);border-radius:999px;background:#f7fafc;}
-.modal__desc{margin:0 0 12px 0;color:#0f172a;}
-
-/* gallery at the end */
-.modal__gallery{
-  display:grid;gap:10px;margin-top:10px;
-  grid-template-columns:repeat(3,1fr);;
-}
-.modal__gallery .g{margin:0;}
-.modal__gallery img{
-  width:100%;height:auto;display:block;object-fit:cover;border-radius:12px;border:1px solid rgba(15,23,42,.08);
-  /* keep a pleasant height even if images vary */
-  aspect-ratio:1/1;
-}
-.modal__gallery{grid-template-columns:repeat(3,1fr);} /* 2-up on desktop */
-
-.modal__meta{
-  margin:2px 0 10px 0;
-  color:var(--muted);
-  font-size:13px;
-  letter-spacing:.2px;
+.proj-card__kw {
+  font-size: 15px;
+  line-height: 1.35;
+  letter-spacing: 0.2px;
+  opacity: 0.98;
 }
 
-/* ===== Experience (sticky rail, auto-height panel) ===== */
-.exp__center{max-width:var(--expW,720px);margin:12px auto 0;}
-.exp__wrap{display:grid;gap:18px;align-items:start;grid-template-columns:64px var(--panelW,560px);}
-
-/* Sticky rail: fixed vertical length, does not cross the title */
-.exp__rail{
-  position:sticky;top:var(--railTop,88px);align-self:start;
-}
-.exp__list{
-  list-style:none;margin:0;padding:12px 0;position:relative;
-  height:var(--railH,calc(100vh - var(--railTop,88px) - 64px)); /* fixed rail length */
-  display:flex;flex-direction:column;justify-content:space-between; /* even spaced dots */
-}
-.exp__list:before{
-  content:"";position:absolute;left:23px;top:0;bottom:0;width:2px;
-  background:rgba(15,23,42,.22);
-  filter:drop-shadow(0 0 1px rgba(15,23,42,.08));
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 60;
 }
 
-/* Dots: slightly bigger, centered on the rail */
-.exp__li{position:relative;margin:0;}
-.exp__dot{
-  width:20px;height:20px;border-radius:999px;display:block;cursor:pointer;
-  border:2px solid rgba(15,23,42,.35);background:#fff;position:relative;
-  left:13px; /* rail(23px) - radius(10px) = 13px; tweak +/-1px if needed */
-  transition:transform .15s ease,border-color .15s ease,box-shadow .15s ease;
-  -webkit-tap-highlight-color:transparent;
-}
-.exp__dot:hover{transform:scale(1.08);border-color:rgba(15,23,42,.6);}
-.exp__dot.is-active{background:var(--accent);border-color:var(--accent);box-shadow:0 0 0 4px rgba(104,143,229,.18);}
-
-/* Story panel: sticky and centered WITHOUT transform (respects bounds) */
-.exp__panel{
-  position:sticky;
-  /* Center using a top offset based on the maximum height */
-  top:calc((100vh - var(--panelMax,50vh))/2);
-  max-height:var(--panelMax,50vh);
-  overflow:auto;
-  overscroll-behavior:contain;
-
-  background:#fff;
-  border:1px solid rgba(15,23,42,.08);
-  border-radius:16px;
-  box-shadow:0 10px 24px rgba(15,23,42,.08);
+.modal__panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(1200px, 80vw);
+  max-height: 85vh;
+  background: #fff;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
 }
 
-/* header uses flex so the logo sits at top-left */
-.exp__head{
-  display:flex;align-items:center;gap:12px;
-  position:sticky;top:0;z-index:1;background:#fff;
-  padding:12px 16px 10px;border-bottom:1px solid rgba(15,23,42,.06);
-  border-top-left-radius:16px;border-top-right-radius:16px;
+.modal__close {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  z-index: 2;
+  border: 0;
+  background: transparent;
+  padding: 6px 8px;
+  font-size: 28px;
+  line-height: 1;
+  color: #111;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.exp__logo{
-  width:56px;height:56px;flex:0 0 56px;
-  object-fit:contain;border-radius:8px;
-  box-shadow:0 0 0 1px rgba(15,23,42,.06) inset;
+.modal__scroll {
+  display: block;
+  overflow: auto;
 }
 
-.exp__headText{min-width:0;} /* prevents flex overflow */
-.exp__title{margin:0 0 4px 0;}
-/* .exp__meta already defined in your file */
-.exp__storywrap{padding:14px 16px 18px;}
-.exp__story{margin:0;color:var(--ink);line-height:1.65;max-width:60ch;}
+.modal__media {
+  aspect-ratio: 21 / 9;
+  background-size: cover;
+  background-position: center;
+}
 
-/* Mobile: static (no sticky, no fixed heights) */
-@media(max-width:820px){
-  .exp__wrap{grid-template-columns:1fr;height:auto;gap:12px;justify-items:center;}
-  .exp__rail{position:static;}
-  .exp__list{display:flex;flex-direction:row;justify-content:center;gap:14px;height:auto;padding:4px 0;}
-  .exp__list:before{display:none;}
-  .exp__dot{left:0;}
-  .exp__panel{
-    position:static;
-    top:auto;
-    max-height:none;
-    width:min(560px,92vw);
-    border-radius:16px;     /* keep rounded corners */
-    overflow:hidden;        /* clip the header to the radius */
+.modal__body {
+  padding: 14px 16px 18px;
+}
+
+.modal__title {
+  margin: 0 0 6px;
+  font-size: 22px;
+}
+
+.modal__meta {
+  margin: 2px 0 10px;
+  font-size: 13px;
+  letter-spacing: 0.2px;
+  color: var(--muted);
+}
+
+.modal__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 10px;
+}
+
+.tag {
+  display: inline-block;
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 999px;
+  background: #f7fafc;
+}
+
+.modal__desc {
+  margin: 0 0 12px;
+  color: #0f172a;
+}
+
+.modal__gallery {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.modal__gallery .g {
+  margin: 0;
+}
+
+.modal__gallery img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 720px) {
+  .modal__panel {
+    width: min(680px, 90vw);
   }
-  .exp__head{position:static;border-bottom:1px solid rgba(15,23,42,.06);}
-  .exp__logo{width:56px;height:56px;flex:0 0 56px;}
+
+  .modal__gallery {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-/* ===== Contact — title first, row beneath; info centered vs form ===== */
-.contact{--infoSize:40px;--infoIcon:40px;--gap:28px;--cardW:560px;--rowW:980px;}
-.contact__title{margin:0 0 0 0;}                 /* full-width section title */
-
-.contact__inner{
-  width:min(100%,var(--rowW));                      /* narrower than title */
-  margin:0 auto;                                    /* centered under title */
-  display:grid;
-  grid-template-columns:minmax(260px,1fr) var(--cardW);
-  gap:var(--gap);
-  align-items:center;                               /* vertical middle align info vs form */
-}
-@media(max-width:900px){
-  .contact__inner{grid-template-columns:1fr;}
+/* =============================================
+   Experience
+   ============================================= */
+.exp__center {
+  max-width: var(--expW, 720px);
+  margin: 12px auto 0;
 }
 
-/* left column */
-.contact__intro{justify-self:center;text-align:left;}
-.contact__list{list-style:none;margin:0;padding:0;display:grid;gap:14px;}
-.contact__link{display:inline-flex;align-items:center;gap:10px;color:var(--ink);}
-.contact__link svg{color:#688FE5;opacity:.95;}
-
-/* right column (form card) */
-.contact__card{
-  background:#fff;border:1px solid rgba(15,23,42,.08);
-  border-radius:16px;box-shadow:0 10px 24px rgba(15,23,42,.08);
-  padding:16px;
+.exp__wrap {
+  display: grid;
+  gap: 18px;
+  align-items: start;
+  grid-template-columns: 64px var(--panelW, 560px);
 }
 
-.grid2{display:grid;gap:12px;grid-template-columns:1fr 1fr;}
-@media(max-width:600px){.grid2{grid-template-columns:1fr;}}
-.field .label{display:block;font-size:14px;color:var(--muted);margin:0 0 6px 2px;}
-.contact__actions{display:flex;justify-content:flex-start;margin-top:4px;}
-.btn{padding:10px 14px;border-radius:12px;border:1px solid var(--accent);background:var(--accent);color:#fff;font-weight:600;cursor:pointer;}
-.btn:hover{filter:brightness(.98);}
-.btn:active{transform:translateY(1px);}
-
-/* === Nav: compact + dark for /photo === */
-.nav--compact .nav__center{display:none;}
-
-.nav--compact .nav__dropdown{
-  position:fixed;inset:var(--navH) 0 0 0;display:none;
-  background:rgba(0,0,0,.85);backdrop-filter:blur(8px);
-  padding:20px;z-index:50;
-}
-.nav--compact .nav__dropdown.nav__dropdown--open{display:block;}
-.nav--compact .nav__dropdown a{
-  display:block;color:#e7ecf7;font-size:18px;padding:12px 6px;
+.exp__rail {
+  position: sticky;
+  top: var(--railTop, 88px);
+  align-self: start;
 }
 
-/* Dark chrome for /photo */
-.nav--dark{
-  background:rgba(0,0,0,.35);
-  border-bottom:1px solid rgba(255,255,255,.08);
-  backdrop-filter:saturate(1.1) blur(10px);
-}
-.nav--dark .nav__brand a,
-.nav--dark .nav__link{color:#e7ecf7;}
-.nav--dark .nav__toggle span{background:#e7ecf7;}
-
-/* ==== Route-scoped dark mode (used by /photo) ==== */
-body.body--dark{
-  /* override your site variables for this route */
-  --bg:#0b141f;
-  --ink:#e6eefc;
-  --muted:#a9b4c8;
-
-  background:var(--bg);
-  color:var(--ink);
+.exp__list {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: var(--railH, calc(100vh - var(--railTop, 88px) - 64px));
+  margin: 0;
+  padding: 12px 0;
+  list-style: none;
 }
 
-body.body--dark .section h2{ color:var(--ink); }
-body.body--dark a{ color:#e6eefc; }
+.exp__list::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 23px;
+  width: 2px;
+  background: rgba(15, 23, 42, 0.22);
+  filter: drop-shadow(0 0 1px rgba(15, 23, 42, 0.08));
+}
 
+.exp__li {
+  position: relative;
+  margin: 0;
+}
+
+.exp__dot {
+  position: relative;
+  left: 13px;
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 2px solid rgba(15, 23, 42, 0.35);
+  background: #fff;
+  cursor: pointer;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.exp__dot:hover {
+  transform: scale(1.08);
+  border-color: rgba(15, 23, 42, 0.6);
+}
+
+.exp__dot.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(104, 143, 229, 0.18);
+}
+
+.exp__panel {
+  position: sticky;
+  top: calc((100vh - var(--panelMax, 50vh)) / 2);
+  max-height: var(--panelMax, 50vh);
+  overflow: auto;
+  overscroll-behavior: contain;
+  background: #fff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.exp__head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px 10px;
+  background: #fff;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+.exp__logo {
+  flex: 0 0 56px;
+  width: 56px;
+  height: 56px;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.06) inset;
+}
+
+.exp__headText {
+  min-width: 0;
+}
+
+.exp__title {
+  margin: 0 0 4px;
+}
+
+.exp__storywrap {
+  padding: 14px 16px 18px;
+}
+
+.exp__story {
+  margin: 0;
+  color: var(--ink);
+  line-height: 1.65;
+  max-width: 60ch;
+}
+
+@media (max-width: 820px) {
+  .exp__wrap {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    justify-items: center;
+  }
+
+  .exp__rail {
+    position: static;
+  }
+
+  .exp__list {
+    flex-direction: row;
+    justify-content: center;
+    gap: 14px;
+    height: auto;
+    padding: 4px 0;
+  }
+
+  .exp__list::before {
+    display: none;
+  }
+
+  .exp__dot {
+    left: 0;
+  }
+
+  .exp__panel {
+    position: static;
+    top: auto;
+    max-height: none;
+    width: min(560px, 92vw);
+    border-radius: 16px;
+    overflow: hidden;
+  }
+
+  .exp__head {
+    position: static;
+  }
+}
+
+/* =============================================
+   Contact
+   ============================================= */
+.contact {
+  --rowW: 980px;
+  --cardW: 560px;
+  --gap: 28px;
+}
+
+.contact__title {
+  margin: 0;
+}
+
+.contact__inner {
+  width: min(100%, var(--rowW));
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) var(--cardW);
+  gap: var(--gap);
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .contact__inner {
+    grid-template-columns: 1fr;
+  }
+}
+
+.contact__intro {
+  justify-self: center;
+  text-align: left;
+}
+
+.contact__list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+  list-style: none;
+}
+
+.contact__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.contact__link svg {
+  color: #688fe5;
+  opacity: 0.95;
+}
+
+.contact__card {
+  padding: 16px;
+  background: #fff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+  max-width: 680px;
+}
+
+.grid2 {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+}
+
+@media (max-width: 600px) {
+  .grid2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.field .label {
+  display: block;
+  margin: 0 0 6px 2px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.contact__actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 4px;
+}
+
+.btn {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn:hover {
+  filter: brightness(0.98);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,20 +1,89 @@
-:root{
-  --bg:#f7fbff;    
-  /* --bg:#f7fbff;  winter */
-  /* --bg:#fffff7;  summer */
-  --primary:#dceeff;
-  --accent:#688FE5;
-  --ink:#0f172a;
-  --muted:#64748b;
-  --max:1100px;
-  --radius:16px;
-  --shadow:0 10px 24px rgba(15,23,42,.08);
-  --navH:50px;
+:root {
+  --bg: #f7fbff;
+  /* --bg: #fffff7;  // summer */
+  --primary: #dceeff;
+  --accent: #688fe5;
+  --ink: #0f172a;
+  --muted: #64748b;
+  --max: 1100px;
+  --radius: 16px;
+  --shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  --navH: 50px;
 }
 
-*{box-sizing:border-box;}
-html,body,#root{height:100%;}
-html{scroll-behavior:smooth;}
-body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";color:var(--ink);background:var(--bg);line-height:1.6;}
-a{text-decoration:none;color:inherit;}
-.container{max-width:var(--max);margin:0 auto;padding:24px 20px;}
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    "Apple Color Emoji",
+    "Segoe UI Emoji";
+  color: var(--ink);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.page-shell {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.page {
+  display: block;
+}
+
+.page--dark {
+  color: inherit;
+}
+
+body.body--dark {
+  --bg: #0b141f;
+  --ink: #e6eefc;
+  --muted: #a9b4c8;
+
+  background: var(--bg);
+  color: var(--ink);
+}
+
+body.body--dark a {
+  color: inherit;
+}
+
+body.body--dark
+  .section
+  :is(
+    h2,
+    .section__title,
+    .about__title,
+    .projects__title,
+    .experience__title,
+    .contact__title
+  ) {
+  color: var(--ink);
+}

--- a/src/views/About.js
+++ b/src/views/About.js
@@ -1,7 +1,7 @@
 import React from "react";
 import aboutImg from "../assets/images/about.jpg";
 
-const About=()=> {
+const About = () => {
   return (
     <section id="about" className="section about">
       <div className="about__wrap">
@@ -9,12 +9,33 @@ const About=()=> {
         <div className="about__text">
           <h2 className="about__title">About Me</h2>
           <p className="about__p">
-            I was born and raised in South Korea <span aria-hidden="true">🇰🇷</span> before moving to Calgary, Canada <span aria-hidden="true">🇨🇦</span> in 2015. I am studying Mechanical Engineering <span aria-hidden="true">⚙️</span> with an Aerospace Minor at the University of Calgary. I am passionate <span aria-hidden="true">🔥</span> about combining engineering and leadership <span aria-hidden="true">🤝</span> to create innovations <span aria-hidden="true">💡</span> that make a meaningful impact on people and communities <span aria-hidden="true">🌍</span>. My strengths include mechanical HVAC systems design <span aria-hidden="true">📐</span> and product/mechanical design engineering (CAD, FEA, CFD, prototyping, manufacturing) <span aria-hidden="true">🛠️</span>. I also bring strong software proficiency <span aria-hidden="true">💻</span> that amplifies the value of engineering in today’s world. I stay active through soccer <span aria-hidden="true">⚽</span> and squash, and I keep creativity alive through photography <span aria-hidden="true">📷</span> and traveling <span aria-hidden="true">✈️</span>.
+            I was born and raised in South Korea{" "}
+            <span aria-hidden="true">🇰🇷</span> before moving to Calgary, Canada{" "}
+            <span aria-hidden="true">🇨🇦</span> in 2015. I am studying Mechanical
+            Engineering <span aria-hidden="true">⚙️</span> with an Aerospace
+            Minor at the University of Calgary. I am passionate{" "}
+            <span aria-hidden="true">🔥</span> about combining engineering and
+            leadership <span aria-hidden="true">🤝</span> to create innovations{" "}
+            <span aria-hidden="true">💡</span> that make a meaningful impact on
+            people and communities <span aria-hidden="true">🌍</span>. My
+            strengths include mechanical HVAC systems design{" "}
+            <span aria-hidden="true">📐</span> and product/mechanical design
+            engineering (CAD, FEA, CFD, prototyping, manufacturing){" "}
+            <span aria-hidden="true">🛠️</span>. I also bring strong software
+            proficiency <span aria-hidden="true">💻</span> that amplifies the
+            value of engineering in today’s world. I stay active through soccer{" "}
+            <span aria-hidden="true">⚽</span> and squash, and I keep creativity
+            alive through photography <span aria-hidden="true">📷</span> and
+            traveling <span aria-hidden="true">✈️</span>.
           </p>
         </div>
         {/* Right: portrait */}
         <figure className="about__media">
-          <img className="about__img about__img--sq" src={aboutImg} alt="Yigon Kim"/>
+          <img
+            className="about__img about__img--sq"
+            src={aboutImg}
+            alt="Yigon Kim"
+          />
           <figcaption className="about__cap">Winery in Kelowna, BC</figcaption>
         </figure>
       </div>

--- a/src/views/Contact.js
+++ b/src/views/Contact.js
@@ -1,17 +1,19 @@
 import React from "react";
 
-const Contact=()=>{
-  const onSubmit=(e)=>{
+const Contact = () => {
+  const onSubmit = (e) => {
     e.preventDefault();
-    const f=new FormData(e.currentTarget);
-    const name=f.get("name"), email=f.get("email"), message=f.get("message");
-    const to="yigon.kim1@gmail.com";
-    const subject=encodeURIComponent(`[Portfolio] Message from ${name}`);
-    const body=encodeURIComponent(`From: ${name} <${email}>\n\n${message}`);
-    window.location.href=`mailto:${to}?subject=${subject}&body=${body}`;
+    const f = new FormData(e.currentTarget);
+    const name = f.get("name"),
+      email = f.get("email"),
+      message = f.get("message");
+    const to = "yigon.kim1@gmail.com";
+    const subject = encodeURIComponent(`[Portfolio] Message from ${name}`);
+    const body = encodeURIComponent(`From: ${name} <${email}>\n\n${message}`);
+    window.location.href = `mailto:${to}?subject=${subject}&body=${body}`;
   };
 
-  return(
+  return (
     <section id="contact" className="section contact" aria-label="Contact">
       {/* Title spans full width */}
       <h2 className="contact__title">Contact</h2>
@@ -23,24 +25,53 @@ const Contact=()=>{
           <ul className="contact__list" aria-label="Direct contact">
             <li>
               <a href="tel:+14039780807" className="contact__link">
-                <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18">
-                  <path fill="currentColor" d="M6.62 10.79a15.52 15.52 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.02-.24c1.12.37 2.33.56 3.57.56a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C11.85 21 3 12.15 3 1a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.24.19 2.45.56 3.57a1 1 0 0 1-.24 1.02l-2.2 2.2Z"/>
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  width="18"
+                  height="18"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M6.62 10.79a15.52 15.52 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.02-.24c1.12.37 2.33.56 3.57.56a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C11.85 21 3 12.15 3 1a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.24.19 2.45.56 3.57a1 1 0 0 1-.24 1.02l-2.2 2.2Z"
+                  />
                 </svg>
                 +1 (403) 978-0807
               </a>
             </li>
             <li>
               <a href="mailto:yigon.kim1@gmail.com" className="contact__link">
-                <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18">
-                  <path fill="currentColor" d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm0 2-8 7L4 6h16Z"/>
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  width="18"
+                  height="18"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm0 2-8 7L4 6h16Z"
+                  />
                 </svg>
                 yigon.kim1@gmail.com
               </a>
             </li>
             <li>
-              <a href="https://www.linkedin.com/in/kim-yigon/" target="_blank" rel="noreferrer" className="contact__link">
-                <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18">
-                  <path fill="currentColor" d="M6.94 8.5H4V20h2.94V8.5ZM5.47 7.16a1.71 1.71 0 1 0 0-3.42 1.71 1.71 0 0 0 0 3.42ZM20 20h-2.92v-5.57c0-1.33-.02-3.05-1.86-3.05-1.87 0-2.16 1.46-2.16 2.96V20H10.1V8.5h2.8v1.57h.04c.39-.73 1.36-1.5 2.8-1.5 2.99 0 3.55 1.97 3.55 4.53V20Z"/>
+              <a
+                href="https://www.linkedin.com/in/kim-yigon/"
+                target="_blank"
+                rel="noreferrer"
+                className="contact__link"
+              >
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  width="18"
+                  height="18"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M6.94 8.5H4V20h2.94V8.5ZM5.47 7.16a1.71 1.71 0 1 0 0-3.42 1.71 1.71 0 0 0 0 3.42ZM20 20h-2.92v-5.57c0-1.33-.02-3.05-1.86-3.05-1.87 0-2.16 1.46-2.16 2.96V20H10.1V8.5h2.8v1.57h.04c.39-.73 1.36-1.5 2.8-1.5 2.99 0 3.55 1.97 3.55 4.53V20Z"
+                  />
                 </svg>
                 LinkedIn
               </a>
@@ -49,24 +80,47 @@ const Contact=()=>{
         </div>
 
         {/* RIGHT: form card */}
-        <div className="contact__card" role="region" aria-label="Send a message">
+        <div
+          className="contact__card"
+          role="region"
+          aria-label="Send a message"
+        >
           <form className="form" onSubmit={onSubmit}>
             <div className="grid2">
               <label className="field">
                 <span className="label">Name</span>
-                <input className="input" type="text" name="name" placeholder="Your name" required/>
+                <input
+                  className="input"
+                  type="text"
+                  name="name"
+                  placeholder="Your name"
+                  required
+                />
               </label>
               <label className="field">
                 <span className="label">Email</span>
-                <input className="input" type="email" name="email" placeholder="you@example.com" required/>
+                <input
+                  className="input"
+                  type="email"
+                  name="email"
+                  placeholder="you@example.com"
+                  required
+                />
               </label>
             </div>
             <label className="field">
               <span className="label">Message</span>
-              <textarea className="textarea" name="message" placeholder="Your message" required/>
+              <textarea
+                className="textarea"
+                name="message"
+                placeholder="Your message"
+                required
+              />
             </label>
             <div className="contact__actions">
-              <button className="btn" type="submit">Send message</button>
+              <button className="btn" type="submit">
+                Send message
+              </button>
             </div>
           </form>
         </div>

--- a/src/views/Experience.js
+++ b/src/views/Experience.js
@@ -1,37 +1,76 @@
-import React,{useState} from "react";
+import React, { useState } from "react";
 import logoStantec from "../assets/images/logos/stantec.jpg";
 import logoAKCSE from "../assets/images/logos/akcse.jpeg";
 import logoMedal from "../assets/images/logos/medal.jpg";
 import logoSUAV from "../assets/images/logos/suav.jpg";
 
-const LOGOS={stantec:logoStantec,akcse:logoAKCSE,medal:logoMedal,suav:logoSUAV};
+const LOGOS = {
+  stantec: logoStantec,
+  akcse: logoAKCSE,
+  medal: logoMedal,
+  suav: logoSUAV,
+};
 
+const ITEMS = [
+  {
+    id: "stantec",
+    label: "Stantec",
+    title: "Mechanical Engineering Intern",
+    org: "Stantec",
+    date: "May 2024 – May 2025",
+    location: "Calgary, AB",
+    story:
+      "I joined the buildings group and learned to design for people first—ventilation that feels right, plumbing that just works, and fire protection that quietly protects. I lived in Revit, set up families, reviewed submittals, and used IES VE to sanity-check performance. My favorite win was automating repeatable calc/markup steps so our team could focus on judgment over drudgery.",
+  },
 
-const ITEMS=[
-  {id:"stantec",label:"Stantec",title:"Mechanical Engineering Intern",org:"Stantec",date:"May 2024 – May 2025",location:"Calgary, AB",
-   story:"I joined the buildings group and learned to design for people first—ventilation that feels right, plumbing that just works, and fire protection that quietly protects. I lived in Revit, set up families, reviewed submittals, and used IES VE to sanity-check performance. My favorite win was automating repeatable calc/markup steps so our team could focus on judgment over drudgery."},
+  {
+    id: "akcse",
+    label: "AKCSE",
+    title: "Vice-President",
+    org: "AKCSE",
+    date: "Sept 2023 – Sept 2025",
+    location: "Calgary, AB",
+    story:
+      "Leadership meant designing the conditions for others to do their best work: clear roles, tight run-of-show docs, and thoughtful follow-ups. We made events welcoming and useful, and I learned how small systems—sign-ups, reminders, room setup—shape the experience.",
+  },
 
-  {id:"akcse",label:"AKCSE",title:"Vice-President",org:"AKCSE",date:"Sept 2023 – Sept 2025",location:"Calgary, AB",
-   story:"Leadership meant designing the conditions for others to do their best work: clear roles, tight run-of-show docs, and thoughtful follow-ups. We made events welcoming and useful, and I learned how small systems—sign-ups, reminders, room setup—shape the experience."},
+  {
+    id: "medal",
+    label: "MEDAL Lab",
+    title: "Research Assistant",
+    org: "MEDAL Lab",
+    date: "May 2023 – Jun 2024",
+    location: "Calgary, AB",
+    story:
+      "In a small lab team, I helped build an early hydrogen/methane sensor prototype—CAD, quick-turn assemblies, and plenty of data scrubbing. Translating messy signals into decisions became the work: what to change next, and why. We moved fast, documented everything, and collaborated internationally toward IP-ready designs.",
+  },
 
-  {id:"medal",label:"MEDAL Lab",title:"Research Assistant",org:"MEDAL Lab",date:"May 2023 – Jun 2024",location:"Calgary, AB",
-   story:"In a small lab team, I helped build an early hydrogen/methane sensor prototype—CAD, quick-turn assemblies, and plenty of data scrubbing. Translating messy signals into decisions became the work: what to change next, and why. We moved fast, documented everything, and collaborated internationally toward IP-ready designs."},
-
-  {id:"suav",label:"Schulich UAV",title:"Mechanical Team Member",org:"Schulich UAV",date:"Sept 2022 – Oct 2023",location:"Calgary, AB",
-   story:"I worked on airframe structures and fixtures—SolidWorks models, FEA checks, and CNCable parts. Competition timelines taught me to trade elegance for robustness, and to love a good checklist. Shipping something that flies is a special kind of motivation."}
+  {
+    id: "suav",
+    label: "Schulich UAV",
+    title: "Mechanical Team Member",
+    org: "Schulich UAV",
+    date: "Sept 2022 – Oct 2023",
+    location: "Calgary, AB",
+    story:
+      "I worked on airframe structures and fixtures—SolidWorks models, FEA checks, and CNCable parts. Competition timelines taught me to trade elegance for robustness, and to love a good checklist. Shipping something that flies is a special kind of motivation.",
+  },
 ];
 
-
-const Experience=()=> {
-  const [sel,setSel]=useState(ITEMS[0]);
+const Experience = () => {
+  const [sel, setSel] = useState(ITEMS[0]);
 
   return (
     <section
       id="experience"
       className="section experience"
-      style={{'--railTop':'88px','--railH':'calc(100vh - 128px)','--panelMax':'50vh','--panelW':'560px'}}
+      style={{
+        "--railTop": "88px",
+        "--railH": "calc(100vh - 128px)",
+        "--panelMax": "50vh",
+        "--panelW": "560px",
+      }}
     >
-
       <h2>Experience</h2>
 
       {/* centered inner container only */}
@@ -40,16 +79,18 @@ const Experience=()=> {
           {/* Left rail */}
           <nav className="exp__rail" aria-label="Experience timeline">
             <ol className="exp__list">
-              {ITEMS.map((it)=> {
-                const active=sel.id===it.id;
+              {ITEMS.map((it) => {
+                const active = sel.id === it.id;
                 return (
                   <li key={it.id} className="exp__li">
                     <button
                       type="button"
-                      className={`exp__dot${active?" is-active":""}`}
-                      onClick={()=>{setSel(it);}}
+                      className={`exp__dot${active ? " is-active" : ""}`}
+                      onClick={() => {
+                        setSel(it);
+                      }}
                       title={`${it.label} • ${it.date}`}
-                      aria-current={active?"true":"false"}
+                      aria-current={active ? "true" : "false"}
                     />
                   </li>
                 );
@@ -58,18 +99,29 @@ const Experience=()=> {
           </nav>
 
           {/* Right panel: tall, scrollable, sticky header */}
-          <article className="exp__panel" role="region" aria-label={`${sel.title} story`}>
+          <article
+            className="exp__panel"
+            role="region"
+            aria-label={`${sel.title} story`}
+          >
             <div className="exp__scroll">
               <header className="exp__head">
                 {LOGOS[sel.id] && (
-                  <img className="exp__logo" src={LOGOS[sel.id]} alt={`${sel.org} logo`} />
+                  <img
+                    className="exp__logo"
+                    src={LOGOS[sel.id]}
+                    alt={`${sel.org} logo`}
+                  />
                 )}
                 <div className="exp__headText">
-                  <h3 className="exp__title">{sel.title} — {sel.org}</h3>
-                  <div className="exp__meta">{[sel.date,sel.location].filter(Boolean).join(" • ")}</div>
+                  <h3 className="exp__title">
+                    {sel.title} — {sel.org}
+                  </h3>
+                  <div className="exp__meta">
+                    {[sel.date, sel.location].filter(Boolean).join(" • ")}
+                  </div>
                 </div>
               </header>
-
 
               <div className="exp__storywrap">
                 <p className="exp__story">{sel.story}</p>
@@ -77,7 +129,6 @@ const Experience=()=> {
               </div>
             </div>
           </article>
-
         </div>
       </div>
     </section>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -5,15 +5,15 @@ import Projects from "./Projects";
 import Experience from "./Experience";
 import Contact from "./Contact";
 
-const Home=()=> {
+const Home = () => {
   return (
-    <main>
-      <Hero/>
-      <About/>
-      <Projects/>
-      <Experience/>
-      <Contact/>
-    </main>
+    <div className="page home">
+      <Hero />
+      <About />
+      <Projects />
+      <Experience />
+      <Contact />
+    </div>
   );
 };
 

--- a/src/views/Photo.js
+++ b/src/views/Photo.js
@@ -8,7 +8,7 @@ const Photo = () => {
   }, []);
 
   return (
-    <main className="page page--dark">
+    <div className="page page--dark">
       <section className="section">
         <h2>Photo</h2>
         <p>
@@ -16,7 +16,7 @@ const Photo = () => {
           and engineering shots.
         </p>
       </section>
-    </main>
+    </div>
   );
 };
 

--- a/src/views/Projects.js
+++ b/src/views/Projects.js
@@ -1,34 +1,124 @@
-import React,{useState} from "react";
+import React, { useState } from "react";
 import ProjectModal from "../components/ProjectModal";
 
-const ITEMS=[
-  {id:"cansat",title:"CANSAT Parachute Mechanism",cover:"https://picsum.photos/1200/520?random=11",keywords:["mechanism","CAD","prototype"],date:"2023",location:"Calgary, AB",affiliate:"University of Calgary",description:"Compact, reliable deployment mechanism for a CanSat payload; design-for-weight and packability.",images:["https://picsum.photos/900/600?random=111","https://picsum.photos/900/600?random=112","https://picsum.photos/900/600?random=113"]},
-  {id:"scramjet",title:"Scramjet CFD Optimization",cover:"https://picsum.photos/1200/520?random=12",keywords:["CFD","aero","optimization"],date:"2024",location:"Calgary, AB",affiliate:"UCalgary (Aero)",description:"Compressible CFD studies; inlet/isolator geometry iterations to improve pressure recovery.",images:["https://picsum.photos/900/600?random=121","https://picsum.photos/900/600?random=122"]},
-  {id:"iesve",title:"Energy Modeling Training Manual",cover:"https://picsum.photos/1200/520?random=13",keywords:["IES VE","BIM","workflow"],date:"2024–2025",location:"Calgary, AB",affiliate:"Stantec",description:"Onboarding manual that standardizes templates and reduces ramp-up time for VE modeling.",images:["https://picsum.photos/900/600?random=131"]},
-  {id:"uav",title:"UAV Design & Manufacturing",cover:"https://picsum.photos/1200/520?random=14",keywords:["UAV","FEA","manufacturing"],date:"2022–2023",location:"Calgary, AB",affiliate:"Schulich UAV",description:"Airframe design, FEA checks, layups, and CNC fixtures for SUAV competition.",images:["https://picsum.photos/900/600?random=141","https://picsum.photos/900/600?random=142","https://picsum.photos/900/600?random=143"]},
-  {id:"sensor",title:"Hydrogen & Methane Sensor System",cover:"https://picsum.photos/1200/520?random=15",keywords:["sensors","data","IP"],date:"2023–2024",location:"Calgary, AB",affiliate:"MEDAL Lab",description:"Prototype integrating gas sensing, DAQ, and packaging supporting patent-oriented work.",images:["https://picsum.photos/900/600?random=151","https://picsum.photos/900/600?random=152"]}
+const ITEMS = [
+  {
+    id: "cansat",
+    title: "CANSAT Parachute Mechanism",
+    cover: "https://picsum.photos/1200/520?random=11",
+    keywords: ["mechanism", "CAD", "prototype"],
+    date: "2023",
+    location: "Calgary, AB",
+    affiliate: "University of Calgary",
+    description:
+      "Compact, reliable deployment mechanism for a CanSat payload; design-for-weight and packability.",
+    images: [
+      "https://picsum.photos/900/600?random=111",
+      "https://picsum.photos/900/600?random=112",
+      "https://picsum.photos/900/600?random=113",
+    ],
+  },
+  {
+    id: "scramjet",
+    title: "Scramjet CFD Optimization",
+    cover: "https://picsum.photos/1200/520?random=12",
+    keywords: ["CFD", "aero", "optimization"],
+    date: "2024",
+    location: "Calgary, AB",
+    affiliate: "UCalgary (Aero)",
+    description:
+      "Compressible CFD studies; inlet/isolator geometry iterations to improve pressure recovery.",
+    images: [
+      "https://picsum.photos/900/600?random=121",
+      "https://picsum.photos/900/600?random=122",
+    ],
+  },
+  {
+    id: "iesve",
+    title: "Energy Modeling Training Manual",
+    cover: "https://picsum.photos/1200/520?random=13",
+    keywords: ["IES VE", "BIM", "workflow"],
+    date: "2024–2025",
+    location: "Calgary, AB",
+    affiliate: "Stantec",
+    description:
+      "Onboarding manual that standardizes templates and reduces ramp-up time for VE modeling.",
+    images: ["https://picsum.photos/900/600?random=131"],
+  },
+  {
+    id: "uav",
+    title: "UAV Design & Manufacturing",
+    cover: "https://picsum.photos/1200/520?random=14",
+    keywords: ["UAV", "FEA", "manufacturing"],
+    date: "2022–2023",
+    location: "Calgary, AB",
+    affiliate: "Schulich UAV",
+    description:
+      "Airframe design, FEA checks, layups, and CNC fixtures for SUAV competition.",
+    images: [
+      "https://picsum.photos/900/600?random=141",
+      "https://picsum.photos/900/600?random=142",
+      "https://picsum.photos/900/600?random=143",
+    ],
+  },
+  {
+    id: "sensor",
+    title: "Hydrogen & Methane Sensor System",
+    cover: "https://picsum.photos/1200/520?random=15",
+    keywords: ["sensors", "data", "IP"],
+    date: "2023–2024",
+    location: "Calgary, AB",
+    affiliate: "MEDAL Lab",
+    description:
+      "Prototype integrating gas sensing, DAQ, and packaging supporting patent-oriented work.",
+    images: [
+      "https://picsum.photos/900/600?random=151",
+      "https://picsum.photos/900/600?random=152",
+    ],
+  },
 ];
 
-const Projects=()=> {
-  const [open,setOpen]=useState(null);
-  const onOpen=(it)=>{setOpen(it);};
-  const onClose=()=>{setOpen(null);};
+const Projects = () => {
+  const [open, setOpen] = useState(null);
+  const onOpen = (it) => {
+    setOpen(it);
+  };
+  const onClose = () => {
+    setOpen(null);
+  };
 
   return (
     <section id="projects" className="section projects">
       <h2>Projects</h2>
       <div className="projects__list">
-        {ITEMS.map((it)=> {
+        {ITEMS.map((it) => {
           return (
-            <button key={it.id} type="button" className="proj-card proj-card--wide" onClick={()=>{onOpen(it);}} aria-label={`${it.title} details`}>
-              <div className="proj-card__img" style={{backgroundImage:`url(${it.cover}),linear-gradient(135deg,#e8eefc,#dceeff)`}}/>
-              <div className="proj-card__label"><div className="proj-card__title">{it.title}</div></div>
-              <div className="proj-card__hover"><div className="proj-card__kw">{it.keywords.join(" • ")}</div></div>
+            <button
+              key={it.id}
+              type="button"
+              className="proj-card proj-card--wide"
+              onClick={() => {
+                onOpen(it);
+              }}
+              aria-label={`${it.title} details`}
+            >
+              <div
+                className="proj-card__img"
+                style={{
+                  backgroundImage: `url(${it.cover}),linear-gradient(135deg,#e8eefc,#dceeff)`,
+                }}
+              />
+              <div className="proj-card__label">
+                <div className="proj-card__title">{it.title}</div>
+              </div>
+              <div className="proj-card__hover">
+                <div className="proj-card__kw">{it.keywords.join(" • ")}</div>
+              </div>
             </button>
           );
         })}
       </div>
-      <ProjectModal item={open} onClose={onClose}/>
+      <ProjectModal item={open} onClose={onClose} />
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- move shared layout and dark-mode handling into reusable classes while updating page wrappers
- rebuild the navigation/footer styling to remove duplication and rely on class-based variants
- normalize component formatting for consistency across the codebase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d780c83af8832d9ad6b3e84eb3c46a