### PR TITLE
Hide navbar after scrolling past hero section

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -8,8 +8,17 @@ const NavBar = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [active, setActive] = useState("");
   const [solid, setSolid] = useState(false);
+  const [hidden, setHidden] = useState(false);
 
   const isPhoto = pathname.startsWith("/photo");
+
+  const getNavHeight = () => {
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue("--navH")
+      .trim();
+    const n = parseInt(v.replace("px", ""), 10);
+    return Number.isFinite(n) ? n : 56;
+  };
 
   // Glass state: black-transparent over hero, light glass after scroll
   useEffect(() => {
@@ -29,14 +38,7 @@ const NavBar = () => {
       setActive("");
       return;
     }
-    const getNavH = () => {
-      const v = getComputedStyle(document.documentElement)
-        .getPropertyValue("--navH")
-        .trim();
-      const n = parseInt(v.replace("px", ""), 10);
-      return Number.isFinite(n) ? n : 56;
-    };
-    const topOffset = getNavH() + 1;
+    const topOffset = getNavHeight() + 1;
     const obs = new IntersectionObserver(
       (entries) => {
         entries.forEach((e) => {
@@ -52,13 +54,41 @@ const NavBar = () => {
     return () => obs.disconnect();
   }, [pathname]);
 
+  // Hide nav once hero is scrolled past
+  useEffect(() => {
+    if (pathname !== "/") {
+      setHidden(false);
+      return;
+    }
+
+    const hero = document.getElementById("home");
+    if (!hero) {
+      setHidden(false);
+      return;
+    }
+
+    const updateHidden = () => {
+      const rect = hero.getBoundingClientRect();
+      const navHeight = getNavHeight();
+      setHidden(rect.bottom <= navHeight);
+    };
+
+    updateHidden();
+    window.addEventListener("scroll", updateHidden, { passive: true });
+    window.addEventListener("resize", updateHidden);
+    return () => {
+      window.removeEventListener("scroll", updateHidden);
+      window.removeEventListener("resize", updateHidden);
+    };
+  }, [pathname]);
+
   const close = () => setMenuOpen(false);
 
   return (
     <header
       className={`nav ${solid ? "nav--glass" : "nav--clear"} ${
         isPhoto ? "nav--dark nav--compact nav--showToggle" : ""
-      }`}
+      }${hidden ? " nav--hidden" : ""}`}
     >
       <div className="nav__wrap">
         {/* Left: brand */}

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -10,10 +10,12 @@
   z-index: 80;
   display: block;
   color: var(--ink);
+  transform: translateY(0);
   transition:
     background 0.25s ease,
     border-color 0.25s ease,
-    color 0.25s ease;
+    color 0.25s ease,
+    transform 0.3s ease;
 }
 
 .nav--clear {
@@ -27,6 +29,11 @@
   background: rgba(255, 255, 255, 0.7);
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
   backdrop-filter: saturate(180%) blur(12px);
+}
+
+.nav--hidden {
+  transform: translateY(calc(-100% - 16px));
+  pointer-events: none;
 }
 
 .nav__wrap {


### PR DESCRIPTION
## Summary
- track the hero section so the navbar hides once it scrolls past on the home page
- add styling to animate the navbar sliding out of view when hidden

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68d7954d5880832da3dde98331849886