### PR TITLE
Fix navbar home detection for GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "yigonportfolioweb",
+  "homepage": "https://yigonk.github.io/portfolio-website-with-AI-project",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -10,7 +10,16 @@ const NavBar = () => {
   const [solid, setSolid] = useState(false);
   const [hidden, setHidden] = useState(false);
 
-  const isPhoto = pathname.startsWith("/photo");
+  const normalizePath = (path) => {
+    if (!path) return "/";
+    const trimmed = path.replace(/\/+$/, "");
+    if (!trimmed) return "/";
+    return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  };
+
+  const currentPath = normalizePath(pathname);
+  const isHome = currentPath === "/" || currentPath === "/index.html";
+  const isPhoto = currentPath.startsWith("/photo");
 
   const getNavHeight = () => {
     const v = getComputedStyle(document.documentElement)
@@ -23,18 +32,18 @@ const NavBar = () => {
   // Glass state: black-transparent over hero, light glass after scroll
   useEffect(() => {
     const onScroll = () => {
-      const onHome = pathname === "/";
+      const onHome = isHome;
       const atTop = window.scrollY < 80;
       setSolid(!(onHome && atTop));
     };
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
-  }, [pathname]);
+  }, [isHome]);
 
   // Scroll spy (home only)
   useEffect(() => {
-    if (pathname !== "/") {
+    if (!isHome) {
       setActive("");
       return;
     }
@@ -52,11 +61,11 @@ const NavBar = () => {
     );
     els.forEach((el) => obs.observe(el));
     return () => obs.disconnect();
-  }, [pathname]);
+  }, [isHome]);
 
   // Hide nav once hero is scrolled past
   useEffect(() => {
-    if (pathname !== "/") {
+    if (!isHome) {
       setHidden(false);
       return;
     }
@@ -80,7 +89,7 @@ const NavBar = () => {
       window.removeEventListener("scroll", updateHidden);
       window.removeEventListener("resize", updateHidden);
     };
-  }, [pathname]);
+  }, [isHome]);
 
   const close = () => setMenuOpen(false);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
@@ -8,9 +8,35 @@ import "./styles/nav.css";
 import "./styles/sections.css";
 import "./styles/footer.css";
 
+const normalizePath = (path) => {
+  if (!path) return "/";
+  const trimmed = path.replace(/\/+$/, "");
+  if (!trimmed) return "/";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+};
+
+const computeBasename = () => {
+  const publicUrl = process.env.PUBLIC_URL;
+  if (!publicUrl || publicUrl === ".") return undefined;
+  try {
+    const url = new URL(publicUrl, "http://localhost");
+    const normalized = normalizePath(url.pathname);
+    return normalized === "/" ? undefined : normalized;
+  } catch (err) {
+    const normalized = normalizePath(publicUrl);
+    return normalized === "/" ? undefined : normalized;
+  }
+};
+
+const AppWithRouter = () => {
+  const basename = useMemo(computeBasename, []);
+
+  return (
+    <BrowserRouter basename={basename}>
+      <App />
+    </BrowserRouter>
+  );
+};
+
 const rootEl = document.getElementById("root");
-createRoot(rootEl).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
-);
+createRoot(rootEl).render(<AppWithRouter />);


### PR DESCRIPTION
## Summary
- compute a BrowserRouter basename from PUBLIC_URL so GitHub Pages serves the home route at the expected path
- simplify NavBar home detection to treat the `/` route as home so the initial style stays consistent across basenames
- define the CRA `homepage` so builds expose PUBLIC_URL on GitHub Pages deployments

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d79cc8af14832db6f3c0a5caa314fc