### PR TITLE
Add loader and animated transitions to portfolio routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
@@ -10,11 +10,28 @@ import PageLoader from "./components/PageLoader";
 const EXIT_DURATION = 240;
 const ENTER_DURATION = 420;
 
+const DARK_ROUTES = new Set(["/photo"]);
+
 const App = () => {
   const location = useLocation();
   const [displayLocation, setDisplayLocation] = useState(location);
   const [stage, setStage] = useState("boot");
   const [loaderState, setLoaderState] = useState("visible");
+
+  useLayoutEffect(() => {
+    const displayIsDark = DARK_ROUTES.has(displayLocation.pathname);
+    const targetIsDark = DARK_ROUTES.has(location.pathname);
+    const shouldDarken = stage === "exiting" ? displayIsDark : targetIsDark;
+
+    if (shouldDarken) {
+      document.body.classList.add("body--dark");
+    } else {
+      document.body.classList.remove("body--dark");
+    }
+    return () => {
+      document.body.classList.remove("body--dark");
+    };
+  }, [stage, location.pathname, displayLocation.pathname]);
 
   useEffect(() => {
     if (stage !== "boot") {

--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,8 @@ import Home from "./views/Home";
 import Photo from "./views/Photo";
 import PageLoader from "./components/PageLoader";
 
-const EXIT_DURATION = 240;
-const ENTER_DURATION = 420;
+const EXIT_DURATION = 200;
+const ENTER_DURATION = 360;
 
 const DARK_ROUTES = new Set(["/photo"]);
 
@@ -21,7 +21,10 @@ const App = () => {
   useLayoutEffect(() => {
     const displayIsDark = DARK_ROUTES.has(displayLocation.pathname);
     const targetIsDark = DARK_ROUTES.has(location.pathname);
-    const shouldDarken = stage === "exiting" ? displayIsDark : targetIsDark;
+    const shouldDarken =
+      stage === "exiting"
+        ? displayIsDark || targetIsDark
+        : targetIsDark;
 
     if (shouldDarken) {
       document.body.classList.add("body--dark");
@@ -38,17 +41,21 @@ const App = () => {
       return undefined;
     }
 
+    let rafId;
+    let timeoutId;
+
     const finishBoot = () => {
       setStage("entering");
     };
 
-    if (document.readyState === "complete") {
-      const id = window.requestAnimationFrame(finishBoot);
-      return () => window.cancelAnimationFrame(id);
-    }
+    rafId = window.requestAnimationFrame(() => {
+      timeoutId = window.setTimeout(finishBoot, 140);
+    });
 
-    window.addEventListener("load", finishBoot, { once: true });
-    return () => window.removeEventListener("load", finishBoot);
+    return () => {
+      if (rafId) window.cancelAnimationFrame(rafId);
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
   }, [stage]);
 
   useEffect(() => {
@@ -85,7 +92,7 @@ const App = () => {
 
   useEffect(() => {
     if (loaderState !== "leaving") return undefined;
-    const timeout = window.setTimeout(() => setLoaderState("hidden"), 220);
+    const timeout = window.setTimeout(() => setLoaderState("hidden"), 160);
     return () => window.clearTimeout(timeout);
   }, [loaderState]);
 

--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,8 @@ import Home from "./views/Home";
 import Photo from "./views/Photo";
 import PageLoader from "./components/PageLoader";
 
-const EXIT_DURATION = 320;
-const ENTER_DURATION = 640;
+const EXIT_DURATION = 240;
+const ENTER_DURATION = 420;
 
 const App = () => {
   const location = useLocation();
@@ -68,7 +68,7 @@ const App = () => {
 
   useEffect(() => {
     if (loaderState !== "leaving") return undefined;
-    const timeout = window.setTimeout(() => setLoaderState("hidden"), 320);
+    const timeout = window.setTimeout(() => setLoaderState("hidden"), 220);
     return () => window.clearTimeout(timeout);
   }, [loaderState]);
 

--- a/src/App.js
+++ b/src/App.js
@@ -33,17 +33,25 @@ const App = () => {
     }
   }, [stage, displayLocation.pathname]);
 
-  useLayoutEffect(() => {
-    const displayIsDark = DARK_ROUTES.has(displayLocation.pathname);
-    const targetIsDark = DARK_ROUTES.has(location.pathname);
-    const shouldDarken =
-      stage === "exiting"
-        ? displayIsDark || targetIsDark
-        : stage === "entering"
-        ? targetIsDark || exitingDarkRef.current
-        : targetIsDark;
+  const displayPath = displayLocation.pathname;
+  const targetPath = location.pathname;
+  const displayIsDark = DARK_ROUTES.has(displayPath);
+  const targetIsDark = DARK_ROUTES.has(targetPath);
 
-    if (shouldDarken) {
+  const shellIsDark = (() => {
+    if (stage === "exiting") {
+      return displayIsDark || targetIsDark;
+    }
+
+    if (stage === "entering") {
+      return targetIsDark || exitingDarkRef.current;
+    }
+
+    return targetIsDark;
+  })();
+
+  useLayoutEffect(() => {
+    if (shellIsDark) {
       document.body.classList.add("body--dark");
     } else {
       document.body.classList.remove("body--dark");
@@ -51,7 +59,7 @@ const App = () => {
     return () => {
       document.body.classList.remove("body--dark");
     };
-  }, [stage, location.pathname, displayLocation.pathname]);
+  }, [shellIsDark]);
 
   useEffect(() => {
     if (stage !== "boot") {
@@ -139,7 +147,7 @@ const App = () => {
         </div>
       </main>
       {showLoader && <PageLoader state={loaderState} />}
-      <Footer />
+      <Footer forceDark={shellIsDark} />
     </>
   );
 };

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,103 @@
-import React from "react";
-import { Routes, Route } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { Routes, Route, useLocation } from "react-router-dom";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
 import ScrollToHash from "./components/ScrollToHash";
 import Home from "./views/Home";
 import Photo from "./views/Photo";
+import PageLoader from "./components/PageLoader";
+
+const EXIT_DURATION = 320;
+const ENTER_DURATION = 640;
 
 const App = () => {
+  const location = useLocation();
+  const [displayLocation, setDisplayLocation] = useState(location);
+  const [stage, setStage] = useState("boot");
+  const [loaderState, setLoaderState] = useState("visible");
+
+  useEffect(() => {
+    if (stage !== "boot") {
+      return undefined;
+    }
+
+    const finishBoot = () => {
+      setStage("entering");
+    };
+
+    if (document.readyState === "complete") {
+      const id = window.requestAnimationFrame(finishBoot);
+      return () => window.cancelAnimationFrame(id);
+    }
+
+    window.addEventListener("load", finishBoot, { once: true });
+    return () => window.removeEventListener("load", finishBoot);
+  }, [stage]);
+
+  useEffect(() => {
+    if (stage === "idle" && location.pathname !== displayLocation.pathname) {
+      setStage("exiting");
+    }
+  }, [location, displayLocation, stage]);
+
+  useEffect(() => {
+    let timeout;
+    if (stage === "entering") {
+      timeout = window.setTimeout(() => setStage("idle"), ENTER_DURATION);
+    } else if (stage === "exiting") {
+      timeout = window.setTimeout(() => {
+        setDisplayLocation(location);
+        setStage("entering");
+      }, EXIT_DURATION);
+    }
+    return () => {
+      if (timeout) window.clearTimeout(timeout);
+    };
+  }, [stage, location]);
+
+  useEffect(() => {
+    if (displayLocation.pathname !== "/" && loaderState !== "hidden") {
+      setLoaderState("hidden");
+      return;
+    }
+
+    if (stage !== "boot" && loaderState === "visible") {
+      setLoaderState("leaving");
+    }
+  }, [stage, loaderState, displayLocation.pathname]);
+
+  useEffect(() => {
+    if (loaderState !== "leaving") return undefined;
+    const timeout = window.setTimeout(() => setLoaderState("hidden"), 320);
+    return () => window.clearTimeout(timeout);
+  }, [loaderState]);
+
+  const contentStage = useMemo(() => {
+    if (stage === "boot") return "boot";
+    if (stage === "entering") return "entering";
+    if (stage === "exiting") return "exiting";
+    return "idle";
+  }, [stage]);
+
+  const showLoader =
+    displayLocation.pathname === "/" && loaderState !== "hidden";
+
   return (
     <>
       <NavBar />
       <main id="main" className="page-shell">
         <ScrollToHash />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/photo" element={<Photo />} />
-          <Route path="*" element={<Home />} />
-        </Routes>
+        <div
+          className={`page-shell__content page-shell__content--${contentStage}`}
+        >
+          <Routes location={displayLocation}>
+            <Route path="/" element={<Home />} />
+            <Route path="/photo" element={<Photo />} />
+            <Route path="*" element={<Home />} />
+          </Routes>
+        </div>
       </main>
+      {showLoader && <PageLoader state={loaderState} />}
       <Footer />
     </>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,10 @@
-import React, { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
@@ -17,6 +23,15 @@ const App = () => {
   const [displayLocation, setDisplayLocation] = useState(location);
   const [stage, setStage] = useState("boot");
   const [loaderState, setLoaderState] = useState("visible");
+  const exitingDarkRef = useRef(false);
+
+  useEffect(() => {
+    if (stage === "exiting") {
+      exitingDarkRef.current = DARK_ROUTES.has(displayLocation.pathname);
+    } else if (stage === "idle") {
+      exitingDarkRef.current = false;
+    }
+  }, [stage, displayLocation.pathname]);
 
   useLayoutEffect(() => {
     const displayIsDark = DARK_ROUTES.has(displayLocation.pathname);
@@ -24,6 +39,8 @@ const App = () => {
     const shouldDarken =
       stage === "exiting"
         ? displayIsDark || targetIsDark
+        : stage === "entering"
+        ? targetIsDark || exitingDarkRef.current
         : targetIsDark;
 
     if (shouldDarken) {

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 
-const Footer = () => {
+const Footer = ({ forceDark = false }) => {
   const year = new Date().getFullYear();
   const { pathname } = useLocation();
-  const isPhoto = pathname.startsWith("/photo");
+  const isPhoto = forceDark || pathname.startsWith("/photo");
 
   return (
     <footer className={`footer${isPhoto ? " footer--dark" : ""}`}>

--- a/src/components/PageLoader.js
+++ b/src/components/PageLoader.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+const PageLoader = ({ state }) => {
+  const className = `page-loader${
+    state === "leaving" ? " page-loader--leaving" : ""
+  }`;
+  return (
+    <div
+      className={className}
+      role="status"
+      aria-live="polite"
+      aria-busy={state !== "hidden"}
+      aria-label="Loading home"
+    >
+      <div className="page-loader__inner">
+        <div className="page-loader__spinner" aria-hidden="true" />
+        <p className="page-loader__text">Preparing the portfolio…</p>
+      </div>
+    </div>
+  );
+};
+
+export default PageLoader;

--- a/src/components/PageLoader.js
+++ b/src/components/PageLoader.js
@@ -4,6 +4,7 @@ const PageLoader = ({ state }) => {
   const className = `page-loader${
     state === "leaving" ? " page-loader--leaving" : ""
   }`;
+
   return (
     <div
       className={className}
@@ -12,10 +13,7 @@ const PageLoader = ({ state }) => {
       aria-busy={state !== "hidden"}
       aria-label="Loading home"
     >
-      <div className="page-loader__inner">
-        <div className="page-loader__spinner" aria-hidden="true" />
-        <p className="page-loader__text">Preparing the portfolio…</p>
-      </div>
+      <div className="page-loader__spinner" aria-hidden="true" />
     </div>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,18 @@ import "./index.css";
 import "./styles/nav.css";
 import "./styles/sections.css";
 import "./styles/footer.css";
+import "./styles/transitions.css";
+import "./styles/photo.css";
+
+const navigationEntries = window.performance?.getEntriesByType?.("navigation");
+const navType = navigationEntries?.[0]?.type;
+const legacyNavType = window.performance?.navigation?.type;
+const isReload = navType === "reload" || legacyNavType === 1;
+
+if (isReload && window.location.hash) {
+  const target = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+  window.location.replace(target);
+}
 
 const rootEl = document.getElementById("root");
 createRoot(rootEl).render(

--- a/src/styles/photo.css
+++ b/src/styles/photo.css
@@ -1,0 +1,65 @@
+.photo {
+  position: relative;
+  min-height: calc(100vh - var(--navH));
+  padding-top: var(--navH);
+  overflow: hidden;
+}
+
+.photo__veil {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(78, 116, 166, 0.4), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(27, 44, 63, 0.55), transparent 65%),
+    linear-gradient(180deg, rgba(10, 16, 24, 0.9), rgba(10, 16, 24, 0.6));
+  opacity: 1;
+  transform: scale(1.05);
+  transition: opacity 900ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 1200ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.photo__content {
+  position: relative;
+  z-index: 1;
+  padding-top: 120px;
+  padding-bottom: 120px;
+  opacity: 0;
+  transform: translateY(36px);
+  transition: opacity 760ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 760ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.photo--ready .photo__veil {
+  opacity: 0;
+  transform: scale(1);
+}
+
+.photo--ready .photo__content {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.photo .section {
+  padding-top: 0;
+}
+
+.photo h2 {
+  font-size: clamp(48px, 6vw, 68px);
+  margin-bottom: 24px;
+}
+
+.photo p {
+  max-width: 60ch;
+  font-size: clamp(18px, 2.4vw, 20px);
+  line-height: 1.6;
+  color: rgba(230, 238, 252, 0.92);
+}
+
+@media (max-width: 720px) {
+  .photo__content {
+    padding-top: 80px;
+    padding-bottom: 80px;
+  }
+}

--- a/src/styles/transitions.css
+++ b/src/styles/transitions.css
@@ -7,7 +7,7 @@
   opacity: 0;
   transform: translateY(28px);
   transition-property: opacity, transform;
-  transition-duration: 420ms;
+  transition-duration: 360ms;
   transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -24,7 +24,7 @@
 }
 
 .page-shell__content--exiting {
-  transition-duration: 240ms;
+  transition-duration: 200ms;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -37,7 +37,7 @@
   background: #0b141f;
   z-index: 999;
   opacity: 1;
-  transition: opacity 220ms ease;
+  transition: opacity 160ms ease;
 }
 
 .page-loader--leaving {

--- a/src/styles/transitions.css
+++ b/src/styles/transitions.css
@@ -1,0 +1,111 @@
+.page-shell {
+  position: relative;
+}
+
+.page-shell__content {
+  position: relative;
+  opacity: 0;
+  transform: translateY(28px);
+  transition-property: opacity, transform;
+  transition-duration: 640ms;
+  transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.page-shell__content--idle,
+.page-shell__content--entering {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.page-shell__content--exiting,
+.page-shell__content--boot {
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+.page-shell__content--exiting {
+  transition-duration: 320ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.page-loader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, #f7fbff 0%, #e8f2ff 100%);
+  color: var(--ink);
+  z-index: 999;
+  opacity: 1;
+  transition: opacity 320ms ease;
+}
+
+.page-loader--leaving {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.page-loader__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 32px 36px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.14);
+  backdrop-filter: blur(16px);
+}
+
+.page-loader__spinner {
+  width: 54px;
+  height: 54px;
+  border-radius: 999px;
+  border: 3px solid rgba(100, 148, 237, 0.25);
+  border-top-color: var(--accent);
+  animation: page-loader-spin 920ms linear infinite;
+}
+
+.page-loader__text {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+@keyframes page-loader-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 540px) {
+  .page-loader__inner {
+    width: min(320px, 92vw);
+    padding: 28px 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-shell__content,
+  .page-shell__content--exiting,
+  .page-loader,
+  .page-loader__spinner,
+  .photo,
+  .photo__veil,
+  .photo__content {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transform: none !important;
+  }
+
+  .page-loader__spinner {
+    animation: none;
+  }
+}

--- a/src/styles/transitions.css
+++ b/src/styles/transitions.css
@@ -7,7 +7,7 @@
   opacity: 0;
   transform: translateY(28px);
   transition-property: opacity, transform;
-  transition-duration: 640ms;
+  transition-duration: 420ms;
   transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -24,7 +24,7 @@
 }
 
 .page-shell__content--exiting {
-  transition-duration: 320ms;
+  transition-duration: 240ms;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -34,11 +34,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(180deg, #f7fbff 0%, #e8f2ff 100%);
-  color: var(--ink);
+  background: #0b141f;
   z-index: 999;
   opacity: 1;
-  transition: opacity 320ms ease;
+  transition: opacity 220ms ease;
 }
 
 .page-loader--leaving {
@@ -46,33 +45,13 @@
   pointer-events: none;
 }
 
-.page-loader__inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  padding: 32px 36px;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.14);
-  backdrop-filter: blur(16px);
-}
-
 .page-loader__spinner {
-  width: 54px;
-  height: 54px;
+  width: 44px;
+  height: 44px;
   border-radius: 999px;
-  border: 3px solid rgba(100, 148, 237, 0.25);
-  border-top-color: var(--accent);
-  animation: page-loader-spin 920ms linear infinite;
-}
-
-.page-loader__text {
-  margin: 0;
-  font-size: 14px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
+  border: 3px solid rgba(230, 238, 252, 0.2);
+  border-top-color: rgba(230, 238, 252, 0.9);
+  animation: page-loader-spin 680ms linear infinite;
 }
 
 @keyframes page-loader-spin {
@@ -85,9 +64,9 @@
 }
 
 @media (max-width: 540px) {
-  .page-loader__inner {
-    width: min(320px, 92vw);
-    padding: 28px 24px;
+  .page-loader__spinner {
+    width: 38px;
+    height: 38px;
   }
 }
 

--- a/src/views/Photo.js
+++ b/src/views/Photo.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 const Photo = () => {
   // Flip body into dark mode while this page is mounted
@@ -7,9 +7,17 @@ const Photo = () => {
     return () => document.body.classList.remove("body--dark");
   }, []);
 
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => setReady(true));
+    return () => window.cancelAnimationFrame(frame);
+  }, []);
+
   return (
-    <div className="page page--dark">
-      <section className="section">
+    <div className={`page page--dark photo${ready ? " photo--ready" : ""}`}>
+      <div className="photo__veil" aria-hidden="true" />
+      <section className="section photo__content">
         <h2>Photo</h2>
         <p>
           Photography gallery coming soon. This will showcase travel, lifestyle,

--- a/src/views/Photo.js
+++ b/src/views/Photo.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useLayoutEffect, useState } from "react";
 
 const Photo = () => {
   // Flip body into dark mode while this page is mounted
-  useEffect(() => {
+  useLayoutEffect(() => {
     document.body.classList.add("body--dark");
     return () => document.body.classList.remove("body--dark");
   }, []);

--- a/src/views/Photo.js
+++ b/src/views/Photo.js
@@ -1,12 +1,6 @@
-import React, { useEffect, useLayoutEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 const Photo = () => {
-  // Flip body into dark mode while this page is mounted
-  useLayoutEffect(() => {
-    document.body.classList.add("body--dark");
-    return () => document.body.classList.remove("body--dark");
-  }, []);
-
   const [ready, setReady] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add a shared route transition shell with an initial home loader overlay
- introduce dedicated animations for the photo gallery entrance and exit
- normalize reload behavior by stripping hash fragments back to the main homepage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d832860f10832db8f0f2ca032e68ee