### PR TITLE
Fix navbar visibility and brand link behavior

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -61,28 +61,66 @@ const NavBar = () => {
       return;
     }
 
-    const hero = document.getElementById("home");
-    if (!hero) {
-      setHidden(false);
-      return;
-    }
+    let cleanup = () => {};
+    let observer;
 
-    const updateHidden = () => {
-      const rect = hero.getBoundingClientRect();
-      const navHeight = getNavHeight();
-      setHidden(rect.bottom <= navHeight);
+    const attachToHero = (heroEl) => {
+      const updateHidden = () => {
+        const rect = heroEl.getBoundingClientRect();
+        const navHeight = getNavHeight();
+        setHidden(rect.bottom <= navHeight);
+      };
+
+      updateHidden();
+      window.addEventListener("scroll", updateHidden, { passive: true });
+      window.addEventListener("resize", updateHidden);
+
+      cleanup = () => {
+        window.removeEventListener("scroll", updateHidden);
+        window.removeEventListener("resize", updateHidden);
+      };
     };
 
-    updateHidden();
-    window.addEventListener("scroll", updateHidden, { passive: true });
-    window.addEventListener("resize", updateHidden);
+    const tryAttach = () => {
+      const hero = document.getElementById("home");
+      if (!hero) {
+        return false;
+      }
+      attachToHero(hero);
+      return true;
+    };
+
+    if (!tryAttach()) {
+      observer = new MutationObserver(() => {
+        if (tryAttach()) {
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
     return () => {
-      window.removeEventListener("scroll", updateHidden);
-      window.removeEventListener("resize", updateHidden);
+      cleanup();
+      if (observer) {
+        observer.disconnect();
+      }
     };
   }, [pathname]);
 
   const close = () => setMenuOpen(false);
+
+  const handleBrandClick = (event) => {
+    close();
+    if (typeof window === "undefined") return;
+
+    if (pathname === "/" && window.location.hash === "#home") {
+      event.preventDefault();
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
 
   return (
     <header
@@ -93,7 +131,7 @@ const NavBar = () => {
       <div className="nav__wrap">
         {/* Left: brand */}
         <div className="nav__brand">
-          <Link to="/" onClick={close}>
+          <Link to={{ pathname: "/", hash: "#home" }} onClick={handleBrandClick}>
             Yigon Kim
           </Link>
         </div>

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -56,6 +56,15 @@
 
 .nav__brand a {
   color: inherit;
+  text-decoration: none;
+  transition: none;
+}
+
+.nav__brand a:hover,
+.nav__brand a:focus,
+.nav__brand a:active {
+  color: inherit;
+  text-decoration: none;
 }
 
 .nav__center {


### PR DESCRIPTION
## Summary
- ensure the navbar hide logic waits for the home hero to mount before binding scroll listeners so it hides consistently after leaving the photo page
- update the brand link to point to the home section and smooth scroll when already on that hash, while removing hover/click styling to keep it logo-like

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d86c78b160832dbd74a4db8cb6510c