### PR TITLE
Adjust hero background alignment

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -53,7 +53,7 @@ const Hero = () => {
         "--heroTop": "140px",
         "--heroH": "100vh",
         "--pFactor": ".22",
-        "--bgBias": "48%",
+        "--bgBias": "42%",
         "--heroTitle": "clamp(48px, 8vw, 88px)",
         "--titleGap": "16px",
         "--titleToTag": "12px",

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -38,9 +38,9 @@ const Hero = () => {
   }, []);
 
   const hashtags = [
+    "# Mechanical Engineering",
     "# Transformational leadership",
     "# Digital integration",
-    "# Mechanical engineering",
     "# Innovative Design",
   ];
 
@@ -53,10 +53,10 @@ const Hero = () => {
         "--heroTop": "140px",
         "--heroH": "100vh",
         "--pFactor": ".22",
-        "--bgBias": "42%",
+        "--bgBias": "60%",
         "--heroTitle": "clamp(48px, 8vw, 88px)",
         "--titleGap": "16px",
-        "--titleToTag": "12px",
+        "--titleToTag": "8px",
         // Adjust --heroPadX or --heroOffsetX to shift the text horizontally,
         // and tweak --heroTop to move it up or down.
         "--heroPadX": "clamp(32px, 5vw, 56px)",

--- a/src/styles/sections.css
+++ b/src/styles/sections.css
@@ -76,7 +76,7 @@
   position: absolute;
   inset: 0;
   background-size: cover;
-  background-position: center;
+  background-position: 50% var(--bgBias, 50%);
   transform: translate3d(0, var(--pY, 0px), 0);
   will-change: transform;
   scale: 1.06;

--- a/src/styles/sections.css
+++ b/src/styles/sections.css
@@ -165,7 +165,7 @@
 .hero__hashtags {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 16px;
+  gap: 4px 12px;
   margin: var(--titleToTag, 18px) 0 0;
   padding: 0;
   list-style: none;
@@ -196,6 +196,17 @@
       var(--heroInsetMax, 360px),
       calc(var(--heroLerpRange) * var(--heroInsetEase, 0.24))
     );
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    min-height: 100vh;
+    margin-bottom: 0;
+  }
+
+  .hero__content {
+    padding-bottom: clamp(48px, 14vh, 96px);
   }
 }
 
@@ -231,7 +242,7 @@
   }
 
   .hero__hashtags {
-    gap: 6px 12px;
+    gap: 4px 10px;
   }
 
   .hero__hashtag {


### PR DESCRIPTION
## Summary
- allow the hero background image to respect the `--bgBias` variable for vertical alignment
- bias the hero background upward so it stays framed when the hero fills the viewport

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68eae74c3830832db3cdabc7085fed1b